### PR TITLE
feat: add parser validations to float and integer literals

### DIFF
--- a/inputs/test.txt
+++ b/inputs/test.txt
@@ -43,6 +43,9 @@ main(){
     #+ Ejemplo de error por asignacion incorrecta +#
     #+ x = 10 +#
 
+    #+ Ejemplo de error por entero mayor a 64 bits +#
+    #+ x:= 18446744073709551616 +#
+
     convDate(1,2,1900)
     convDate(a1,2,1900)
 }

--- a/src/grammar_actions.rs
+++ b/src/grammar_actions.rs
@@ -1,11 +1,11 @@
 use super::grammar::{Context, TokenKind};
 use super::grammar_lexer::Input;
-use crate::context::{
-    write_to_lexer_file, write_to_parser_file, write_to_symbol_table_file,
-};
+use crate::context::{write_to_lexer_file, write_to_parser_file, write_to_symbol_table_file};
+use crate::grammar_lexer::log_error;
+use crate::read_source_to_string;
 /// This file is maintained by rustemo but can be modified manually.
 /// All manual changes will be preserved except non-doc comments.
-use rustemo::{Input as RustemoInput, Token as RustemoToken};
+use rustemo::{Context as RustemoContext, Input as RustemoInput, Token as RustemoToken};
 use std::fmt::Display;
 pub type Ctx<'i> = Context<'i, Input>;
 #[allow(dead_code)]
@@ -25,15 +25,53 @@ pub fn token_string(_ctx: &Ctx, token: Token) -> TokenString {
     write_to_lexer_file(&format!("STRING: {}", token.value));
     token.value.into()
 }
-pub type TokenIntLiteral = String;
-pub fn token_int_literal(_ctx: &Ctx, token: Token) -> TokenIntLiteral {
+pub type TokenIntLiteral = u64;
+pub fn token_int_literal(ctx: &Ctx, token: Token) -> TokenIntLiteral {
     write_to_lexer_file(&format!("INT_LITERAL: {}", token.value));
-    token.value.into()
+    match token.value.parse() {
+        Err(e) => {
+            log_error(
+                ctx.range(),
+                crate::CompilerError::Parser(format!("Invalid integer literal {e}")),
+                0,
+                &read_source_to_string().unwrap(),
+            );
+            std::process::exit(1)
+        }
+        Ok(value) => value,
+    }
 }
-pub type TokenFloatLiteral = String;
-pub fn token_float_literal(_ctx: &Ctx, token: Token) -> TokenFloatLiteral {
+#[derive(Debug, Clone)]
+pub struct TokenFloatLiteral {
+    original: String,
+    parsed: f64,
+}
+pub fn token_float_literal(ctx: &Ctx, token: Token) -> TokenFloatLiteral {
     write_to_lexer_file(&format!("FLOAT_LITERAL: {}", token.value));
-    token.value.into()
+    let value: f64 = match token.value.parse() {
+        Err(e) => {
+            log_error(
+                ctx.range(),
+                crate::CompilerError::Parser(format!("Invalid float literal {e}")),
+                0,
+                &read_source_to_string().unwrap(),
+            );
+            std::process::exit(1)
+        }
+        Ok(value) => value,
+    };
+    if value.is_subnormal() {
+        log_error(
+            ctx.range(),
+            crate::CompilerError::Parser(format!("Invalid float literal because its: {value}")),
+            0,
+            &read_source_to_string().unwrap(),
+        );
+    }
+    TokenFloatLiteral {
+        original: token.value.to_string(),
+        parsed: value,
+    }
 }
 pub type TokenStringLiteral = String;
 /// Parses a TokenStringLiteral by removing the "" and returning an owned string
@@ -215,11 +253,9 @@ pub fn program_program(
     body: Body,
     token_cbclose: TokenCBClose,
 ) -> Program {
-    write_to_parser_file(
-        &format!(
-            "<Program> -> {token_id} {token_par_open} {token_par_close} {token_cbopen} <Body> {token_cbclose}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<Program> -> {token_id} {token_par_open} {token_par_close} {token_cbopen} <Body> {token_cbclose}"
+    ));
     Program {
         token_id,
         token_par_open,
@@ -254,17 +290,18 @@ pub fn body_body_init_expressions(
     expressions: Expressions,
 ) -> Body {
     write_to_parser_file(&format!("<Body> -> {token_init} <InitBody> <Expressions>"));
-    Some(
-        BodyNoO::BodyInitExpressions(BodyInitExpressions {
-            token_init,
-            init_body,
-            expressions,
-        }),
-    )
+    Some(BodyNoO::BodyInitExpressions(BodyInitExpressions {
+        token_init,
+        init_body,
+        expressions,
+    }))
 }
 pub fn body_body_init(_ctx: &Ctx, token_init: TokenInit, init_body: InitBody) -> Body {
     write_to_parser_file(&format!("<Body> -> {token_init} <InitBody>"));
-    Some(BodyNoO::BodyInit(BodyInit { token_init, init_body }))
+    Some(BodyNoO::BodyInit(BodyInit {
+        token_init,
+        init_body,
+    }))
 }
 pub fn body_body_expressions(_ctx: &Ctx, expressions: Expressions) -> Body {
     ///write_to_parser_file(&format!("<Body> -> <Expressions>"));
@@ -286,9 +323,9 @@ pub fn init_body_init_body(
     var_declarations: VarDeclarations,
     token_cbclose: TokenCBClose,
 ) -> InitBody {
-    write_to_parser_file(
-        &format!("<InitBody> -> {token_cbopen} <VarDeclarations> {token_cbclose}"),
-    );
+    write_to_parser_file(&format!(
+        "<InitBody> -> {token_cbopen} <VarDeclarations> {token_cbclose}"
+    ));
     InitBody {
         token_cbopen,
         var_declarations,
@@ -309,11 +346,9 @@ pub fn function_read_function_read_call(
     token_id: TokenId,
     token_par_close: TokenParClose,
 ) -> FunctionRead {
-    write_to_parser_file(
-        &format!(
-            "<FunctionRead> -> {token_read} {token_par_open} {token_id} {token_par_close}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<FunctionRead> -> {token_read} {token_par_open} {token_id} {token_par_close}"
+    ));
     FunctionRead {
         token_read,
         token_par_open,
@@ -335,11 +370,9 @@ pub fn function_write_function_write_call(
     simple_expression: SimpleExpression,
     token_par_close: TokenParClose,
 ) -> FunctionWrite {
-    write_to_parser_file(
-        &format!(
-            "<FunctionWrite> -> {token_write} {token_par_open} <SimpleExpression> {token_par_close}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<FunctionWrite> -> {token_write} {token_par_open} <SimpleExpression> {token_par_close}"
+    ));
     FunctionWrite {
         token_write,
         token_par_open,
@@ -361,11 +394,9 @@ pub fn function_is_zero_function_is_zero_call(
     arithmetic_expression: ArithmeticExpression,
     token_par_close: TokenParClose,
 ) -> FunctionIsZero {
-    write_to_parser_file(
-        &format!(
-            "<FunctionIsZero> -> {token_is_zero} {token_par_open} <E> {token_par_close}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<FunctionIsZero> -> {token_is_zero} {token_par_open} <E> {token_par_close}"
+    ));
     FunctionIsZero {
         token_is_zero,
         token_par_open,
@@ -395,11 +426,9 @@ pub fn function_conv_date_function_conv_date_variable_call(
     integer_token_7: IntegerValue,
     token_par_close: TokenParClose,
 ) -> FunctionConvDate {
-    write_to_parser_file(
-        &format!(
-            "<FunctionConvDate> -> {token_conv_date} {token_par_open} <IntegerValue> {token_comma_4} <IntegerValue> {token_comma_6} <IntegerValue> {token_par_close}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<FunctionConvDate> -> {token_conv_date} {token_par_open} <IntegerValue> {token_comma_4} <IntegerValue> {token_comma_6} <IntegerValue> {token_par_close}"
+    ));
     FunctionConvDate {
         token_conv_date,
         token_par_open,
@@ -464,9 +493,9 @@ pub fn var_declaration_var_declaration_single(
     token_colon: TokenColon,
     data_type: DataType,
 ) -> VarDeclaration {
-    write_to_parser_file(
-        &format!("<VarDeclaration> -> {token_id} {token_colon} <DataType>"),
-    );
+    write_to_parser_file(&format!(
+        "<VarDeclaration> -> {token_id} {token_colon} <DataType>"
+    ));
     VarDeclaration::VarDeclarationSingle(VarDeclarationSingle {
         token_id,
         token_colon,
@@ -479,9 +508,9 @@ pub fn var_declaration_var_declaration_recursive(
     token_comma: TokenComma,
     var_declaration: VarDeclaration,
 ) -> VarDeclaration {
-    write_to_parser_file(
-        &format!("<VarDeclaration> -> {token_id} {token_comma} <VarDeclaration>"),
-    );
+    write_to_parser_file(&format!(
+        "<VarDeclaration> -> {token_id} {token_comma} <VarDeclaration>"
+    ));
     VarDeclaration::VarDeclarationRecursive(VarDeclarationRecursive {
         token_id,
         token_comma,
@@ -527,17 +556,11 @@ pub fn statement_statement_assignment(_ctx: &Ctx, assignment: Assignment) -> Sta
     ///write_to_parser_file(&format!("<Statement> -> <Assignment>"));
     Statement::StatementAssignment(assignment)
 }
-pub fn statement_statement_if_statement(
-    _ctx: &Ctx,
-    if_statement: IfStatement,
-) -> Statement {
+pub fn statement_statement_if_statement(_ctx: &Ctx, if_statement: IfStatement) -> Statement {
     ///write_to_parser_file(&format!("<Statement> -> <IfStatement>"));
     Statement::StatementIfStatement(if_statement)
 }
-pub fn statement_statement_else_statement(
-    _ctx: &Ctx,
-    else_statement: ElseStatement,
-) -> Statement {
+pub fn statement_statement_else_statement(_ctx: &Ctx, else_statement: ElseStatement) -> Statement {
     ///write_to_parser_file(&format!("<Statement> -> <ElseStatement>"));
     Statement::StatementElseStatement(else_statement)
 }
@@ -545,10 +568,7 @@ pub fn statement_statement_while(_ctx: &Ctx, while_loop: WhileLoop) -> Statement
     ///write_to_parser_file(&format!("<Statement> -> <WhileLoop>"));
     Statement::StatementWhile(while_loop)
 }
-pub fn statement_statement_write(
-    _ctx: &Ctx,
-    function_write: FunctionWrite,
-) -> Statement {
+pub fn statement_statement_write(_ctx: &Ctx, function_write: FunctionWrite) -> Statement {
     ///write_to_parser_file(&format!("<Statement> -> <FunctionWrite>"));
     Statement::StatementWrite(function_write)
 }
@@ -575,9 +595,9 @@ pub fn assignment_assignment(
     token_assign: TokenAssign,
     simple_expression: SimpleExpression,
 ) -> Assignment {
-    write_to_parser_file(
-        &format!("<Assignment> -> {token_id} {token_assign} <SimpleExpression>"),
-    );
+    write_to_parser_file(&format!(
+        "<Assignment> -> {token_id} {token_assign} <SimpleExpression>"
+    ));
     Assignment {
         token_id,
         token_assign,
@@ -622,11 +642,9 @@ pub fn while_loop_while(
     body: Body,
     token_cbclose: TokenCBClose,
 ) -> WhileLoop {
-    write_to_parser_file(
-        &format!(
-            "<WhileLoop> -> {token_while} {token_par_open} <BooleanExpression> {token_par_close} {token_cbopen} <Body> {token_cbclose}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<WhileLoop> -> {token_while} {token_par_open} <BooleanExpression> {token_par_close} {token_cbopen} <Body> {token_cbclose}"
+    ));
     WhileLoop {
         token_while,
         token_par_open,
@@ -657,11 +675,9 @@ pub fn if_statement_if_statement(
     body: Body,
     token_cbclose: TokenCBClose,
 ) -> IfStatement {
-    write_to_parser_file(
-        &format!(
-            "<IfStatement> -> {token_if} {token_par_open} <BooleanExpression> {token_par_close} {token_cbopen} <Body> {token_cbclose}"
-        ),
-    );
+    write_to_parser_file(&format!(
+        "<IfStatement> -> {token_if} {token_par_open} <BooleanExpression> {token_par_close} {token_cbopen} <Body> {token_cbclose}"
+    ));
     IfStatement {
         token_if,
         token_par_open,
@@ -686,9 +702,9 @@ pub fn else_statement_else_statement(
     body: Body,
     token_cbclose: TokenCBClose,
 ) -> ElseStatement {
-    write_to_parser_file(
-        &format!("<ElseStatement> -> {token_else} {token_cbopen} <Body> {token_cbclose}"),
-    );
+    write_to_parser_file(&format!(
+        "<ElseStatement> -> {token_else} {token_cbopen} <Body> {token_cbclose}"
+    ));
     ElseStatement {
         token_else,
         token_cbopen,
@@ -713,9 +729,7 @@ pub enum BooleanExpression {
     BooleanExpressionSimpleExpression(BooleanExpressionSimpleExpression),
     BooleanExpressionTrue(TokenTrue),
     BooleanExpressionFalse(TokenFalse),
-    BooleanExpressionSimpleExpressionRecursive(
-        BooleanExpressionSimpleExpressionRecursive,
-    ),
+    BooleanExpressionSimpleExpressionRecursive(BooleanExpressionSimpleExpressionRecursive),
     BooleanExpressionNotStatement(NotStatement),
     BooleanExpressionIsZero(FunctionIsZero),
 }
@@ -753,17 +767,17 @@ pub fn boolean_expression_boolean_expression_simple_expression_recursive(
     conjunction: Conjunction,
     boolean_expression: BooleanExpression,
 ) -> BooleanExpression {
-    write_to_parser_file(
-        &format!(
-            "<BooleanExpression> -> <SimpleExpression> <BooleanExpressionChain> {conjunction:?} <BooleanExpression>"
-        ),
-    );
-    BooleanExpression::BooleanExpressionSimpleExpressionRecursive(BooleanExpressionSimpleExpressionRecursive {
-        simple_expression,
-        boolean_expression_chain,
-        conjunction,
-        boolean_expression: Box::new(boolean_expression),
-    })
+    write_to_parser_file(&format!(
+        "<BooleanExpression> -> <SimpleExpression> <BooleanExpressionChain> {conjunction:?} <BooleanExpression>"
+    ));
+    BooleanExpression::BooleanExpressionSimpleExpressionRecursive(
+        BooleanExpressionSimpleExpressionRecursive {
+            simple_expression,
+            boolean_expression_chain,
+            conjunction,
+            boolean_expression: Box::new(boolean_expression),
+        },
+    )
 }
 pub fn boolean_expression_boolean_expression_not_statement(
     _ctx: &Ctx,
@@ -825,12 +839,13 @@ pub fn simple_expression_simple_expression_string(
     _ctx: &Ctx,
     token_string_literal: TokenStringLiteral,
 ) -> SimpleExpression {
-    write_to_symbol_table_file(
-        &format!(
-            "{}|{}|{}|{}", token_string_literal, "CONST_STRING", token_string_literal,
-            token_string_literal.len()
-        ),
-    );
+    write_to_symbol_table_file(&format!(
+        "{}|{}|{}|{}",
+        token_string_literal,
+        "CONST_STRING",
+        token_string_literal,
+        token_string_literal.len()
+    ));
     write_to_parser_file(&format!("<SimpleExpression> -> {token_string_literal}"));
     SimpleExpression::SimpleExpressionString(token_string_literal)
 }
@@ -856,10 +871,7 @@ pub enum ComparisonOp {
     ComparisonOpGreater(TokenGreater),
     ComparisonOpGreaterEqual(TokenGreaterEqual),
 }
-pub fn comparison_op_comparison_op_equal(
-    _ctx: &Ctx,
-    token_equal: TokenEqual,
-) -> ComparisonOp {
+pub fn comparison_op_comparison_op_equal(_ctx: &Ctx, token_equal: TokenEqual) -> ComparisonOp {
     write_to_parser_file(&format!("<ComparisonOp> -> {token_equal}"));
     ComparisonOp::ComparisonOpEqual(token_equal)
 }
@@ -870,10 +882,7 @@ pub fn comparison_op_comparison_op_not_equal(
     write_to_parser_file(&format!("<ComparisonOp> -> {token_not_equal}"));
     ComparisonOp::ComparisonOpNotEqual(token_not_equal)
 }
-pub fn comparison_op_comparison_op_less(
-    _ctx: &Ctx,
-    token_less: TokenLess,
-) -> ComparisonOp {
+pub fn comparison_op_comparison_op_less(_ctx: &Ctx, token_less: TokenLess) -> ComparisonOp {
     write_to_parser_file(&format!("<ComparisonOp> -> {token_less}"));
     ComparisonOp::ComparisonOpLess(token_less)
 }
@@ -916,26 +925,25 @@ pub struct NumberNegativeFloat {
     pub token_float_literal: TokenFloatLiteral,
 }
 pub fn number_number_int(_ctx: &Ctx, token_int_literal: TokenIntLiteral) -> Number {
-    write_to_symbol_table_file(
-        &format!(
-            "{}|{}|{}|{}", token_int_literal, "CONST_INT", token_int_literal,
-            token_int_literal.len()
-        ),
-    );
+    write_to_symbol_table_file(&format!(
+        "{}|{}|{}|{}",
+        token_int_literal,
+        "CONST_INT",
+        token_int_literal,
+        token_int_literal.to_string().len()
+    ));
     write_to_parser_file(&format!("<Number> -> {token_int_literal}"));
     Number::NumberInt(token_int_literal)
 }
-pub fn number_number_float(
-    _ctx: &Ctx,
-    token_float_literal: TokenFloatLiteral,
-) -> Number {
-    write_to_symbol_table_file(
-        &format!(
-            "{}|{}|{}|{}", token_float_literal, "CONST_FLOAT", token_float_literal,
-            token_float_literal.len()
-        ),
-    );
-    write_to_parser_file(&format!("<Number> -> {token_float_literal}"));
+pub fn number_number_float(_ctx: &Ctx, token_float_literal: TokenFloatLiteral) -> Number {
+    write_to_symbol_table_file(&format!(
+        "{}|{}|{}|{}",
+        token_float_literal.original,
+        "CONST_FLOAT",
+        token_float_literal.original,
+        token_float_literal.original.len()
+    ));
+    write_to_parser_file(&format!("<Number> -> {}", token_float_literal.original));
     Number::NumberFloat(token_float_literal)
 }
 pub fn number_number_negative_int(
@@ -943,12 +951,13 @@ pub fn number_number_negative_int(
     token_sub: TokenSub,
     token_int_literal: TokenIntLiteral,
 ) -> Number {
-    write_to_symbol_table_file(
-        &format!(
-            "-{}|{}|{}|-{}", token_int_literal, "CONST_INT", token_int_literal,
-            token_int_literal.len() + 1
-        ),
-    );
+    write_to_symbol_table_file(&format!(
+        "-{}|{}|-{}|{}",
+        token_int_literal,
+        "CONST_INT",
+        token_int_literal,
+        token_int_literal.to_string().len() + 1
+    ));
     write_to_parser_file(&format!("<Number> -> {token_sub} {token_int_literal}"));
     Number::NumberNegativeInt(NumberNegativeInt {
         token_sub,
@@ -960,13 +969,17 @@ pub fn number_number_negative_float(
     token_sub: TokenSub,
     token_float_literal: TokenFloatLiteral,
 ) -> Number {
-    write_to_symbol_table_file(
-        &format!(
-            "-{}|{}|{}|-{}", token_float_literal, "CONST_FLOAT", token_float_literal,
-            token_float_literal.len() + 1
-        ),
-    );
-    write_to_parser_file(&format!("<Number> -> {token_sub} {token_float_literal}"));
+    write_to_symbol_table_file(&format!(
+        "-{}|{}|-{}|{}",
+        token_float_literal.original,
+        "CONST_FLOAT",
+        token_float_literal.original,
+        token_float_literal.original.len() + 1
+    ));
+    write_to_parser_file(&format!(
+        "<Number> -> {token_sub} {}",
+        token_float_literal.original
+    ));
     Number::NumberNegativeFloat(NumberNegativeFloat {
         token_sub,
         token_float_literal,
@@ -982,7 +995,9 @@ pub fn not_statement_not(
     token_not: TokenNot,
     boolean_expression: BooleanExpression,
 ) -> NotStatement {
-    write_to_parser_file(&format!("<NotStatement> -> {token_not} <BooleanExpression>"));
+    write_to_parser_file(&format!(
+        "<NotStatement> -> {token_not} <BooleanExpression>"
+    ));
     NotStatement {
         token_not,
         boolean_expression: Box::new(boolean_expression),
@@ -1012,9 +1027,9 @@ pub fn arithmetic_expression_arithmetic_expression_sum_term(
     token_sum: TokenSum,
     term: Term,
 ) -> ArithmeticExpression {
-    write_to_parser_file(
-        &format!("<ArithmeticExpression> -> <ArithmeticExpression> {token_sum} <Term>"),
-    );
+    write_to_parser_file(&format!(
+        "<ArithmeticExpression> -> <ArithmeticExpression> {token_sum} <Term>"
+    ));
     ArithmeticExpression::ArithmeticExpressionSumTerm(ArithmeticExpressionSumTerm {
         arithmetic_expression: Box::new(arithmetic_expression),
         token_sum,
@@ -1027,9 +1042,9 @@ pub fn arithmetic_expression_arithmetic_expression_sub_term(
     token_sub: TokenSub,
     term: Term,
 ) -> ArithmeticExpression {
-    write_to_parser_file(
-        &format!("<ArithmeticExpression> -> <ArithmeticExpression> {token_sub} <Term>"),
-    );
+    write_to_parser_file(&format!(
+        "<ArithmeticExpression> -> <ArithmeticExpression> {token_sub} <Term>"
+    ));
     ArithmeticExpression::ArithmeticExpressionSubTerm(ArithmeticExpressionSubTerm {
         arithmetic_expression: Box::new(arithmetic_expression),
         token_sub,
@@ -1061,12 +1076,7 @@ pub enum Term {
     TermDivFactor(TermDivFactor),
     TermFactor(Factor),
 }
-pub fn term_term_mul_factor(
-    _ctx: &Ctx,
-    term: Term,
-    token_mul: TokenMul,
-    factor: Factor,
-) -> Term {
+pub fn term_term_mul_factor(_ctx: &Ctx, term: Term, token_mul: TokenMul, factor: Factor) -> Term {
     write_to_parser_file(&format!("<Term> -> <Term> {token_mul} <Factor>"));
     Term::TermMulFactor(TermMulFactor {
         term: Box::new(term),
@@ -1074,12 +1084,7 @@ pub fn term_term_mul_factor(
         factor,
     })
 }
-pub fn term_term_div_factor(
-    _ctx: &Ctx,
-    term: Term,
-    token_div: TokenDiv,
-    factor: Factor,
-) -> Term {
+pub fn term_term_div_factor(_ctx: &Ctx, term: Term, token_div: TokenDiv, factor: Factor) -> Term {
     write_to_parser_file(&format!("<Term> -> <Term> {token_div} <Factor>"));
     Term::TermDivFactor(TermDivFactor {
         term: Box::new(term),
@@ -1117,9 +1122,9 @@ pub fn factor_factor_paren(
     arithmetic_expression: ArithmeticExpression,
     token_par_close: TokenParClose,
 ) -> Factor {
-    write_to_parser_file(
-        &format!("<Factor> -> {token_par_open} <ArithmeticExpression> {token_par_close}"),
-    );
+    write_to_parser_file(&format!(
+        "<Factor> -> {token_par_open} <ArithmeticExpression> {token_par_close}"
+    ));
     Factor::FactorParen(FactorParen {
         token_par_open,
         arithmetic_expression: Box::new(arithmetic_expression),
@@ -1135,12 +1140,13 @@ pub fn integer_value_integer_value_literal(
     _ctx: &Ctx,
     token_int_literal: TokenIntLiteral,
 ) -> IntegerValue {
-    write_to_symbol_table_file(
-        &format!(
-            "{}|{}|{}|{}", token_int_literal, "CONST_INT", token_int_literal,
-            token_int_literal.len()
-        ),
-    );
+    write_to_symbol_table_file(&format!(
+        "{}|{}|{}|{}",
+        token_int_literal,
+        "CONST_INT",
+        token_int_literal,
+        token_int_literal.to_string().len()
+    ));
     write_to_parser_file(&format!("<IntegerValue> -> {token_int_literal}"));
     IntegerValue::IntegerValueLiteral(token_int_literal)
 }
@@ -1152,22 +1158,24 @@ impl VarDeclaration {
     pub fn write_to_symbol_table(&self) -> DataType {
         match self {
             Self::VarDeclarationSingle(single) => {
-                write_to_symbol_table_file(
-                    &format!(
-                        "{}|{}|{}|{}", single.token_id, single.data_type, "-", single
-                        .token_id.len()
-                    ),
-                );
+                write_to_symbol_table_file(&format!(
+                    "{}|{}|{}|{}",
+                    single.token_id,
+                    single.data_type,
+                    "-",
+                    single.token_id.len()
+                ));
                 single.data_type.clone()
             }
             Self::VarDeclarationRecursive(recursive) => {
                 let data_type = recursive.var_declaration.write_to_symbol_table();
-                write_to_symbol_table_file(
-                    &format!(
-                        "{}|{}|{}|{}", recursive.token_id, data_type, "-", recursive
-                        .token_id.len()
-                    ),
-                );
+                write_to_symbol_table_file(&format!(
+                    "{}|{}|{}|{}",
+                    recursive.token_id,
+                    data_type,
+                    "-",
+                    recursive.token_id.len()
+                ));
                 data_type
             }
         }


### PR DESCRIPTION
**Description**

This PR modifies the types `TokenIntLiteral` and `TokenFloatLiteral` to be parsed to u64 and f64 respectively and return proper errors in case they can't be parsed 