### PR TITLE
fix: remove default file arg from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cargo build --release
 
 1. Run in debug mode
 ```Shell
-cargo run
+cargo run -- <INPUT-FILE>
 ```
 
 2. Run in release mode

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ cargo run
 
 2. Run in release mode
 ```Shell
-cargo run --release
+cargo run --release -- <INPUT-FILE>
 ```
 
-The executable can accept an input file as a parmeter and will by default run the file located at './inputs/test.txt'.
+The executable requires an input file as a parmeter.
 
 ## Running the tests
 
@@ -77,10 +77,10 @@ When running the compiler it will output 3 files to the path of the source file
 ## Cli reference
 
 ```
-Usage: lm-compiler [INPUT]
+Usage: lm-compiler <INPUT_FILE>
 
 Arguments:
-  [INPUT]  Path to the source code file [default: ./Inputs/test.txt]
+  <INPUT_FILE>  Path to the source code file
 
 Options:
   -h, --help     Print help

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,7 @@ use std::path::PathBuf;
     about = "Simple compiler written in Rust for the Compilers & Languages class at UNLaM"
 )]
 struct Cli {
-    #[arg(
-        help = "Path to the source code file",
-        default_value = "./inputs/test.txt"
-    )]
+    #[arg(help = "Path to the source code file", value_name = "INPUT_FILE")]
     input: PathBuf,
 }
 


### PR DESCRIPTION
**Description**

Currently the CLI expects a file located in `input/test.txt` this PR removes this default and expects to get the file as an argument