### PR TITLE
feat: remove requirement for `main()`

### DIFF
--- a/inputs/test.txt
+++ b/inputs/test.txt
@@ -1,50 +1,48 @@
-main(){
-    init {
-        a1, b2 : int
-        c33, d4, e5 : float
-        f6f, g : string
+init {
+    a1, b2 : int
+    c33, d4, e5 : float
+    f6f, g : string
 
-        #+ Ejemplo de una variable mal declarada +#
-        #+ fecha : date +#
-        #+ h : foat +#
-    }
-    
-    a1 := -125
-    b2 := a1
-
-    c33 := 5.34
-    d4 := c33-2.1
-    e5 := -5.1 #+ numero "negativo" +#
-
-    f6f := "hola \n como estas"
-    g := "que onda"
-
-    #+ comentario +#
-
-    if(a1 > b2) {
-        a1 := 10
-    }
-    else {
-        b2 := 20
-    }
-
-    while(c33 == 5.34 and d4 <= 2 < c33 or e5 >= 1) {
-        a1 := a1+1
-        if(not isZero(a1)) {
-            a1 := -125
-        }
-    }
-
-    write("hola")
-    write(g)
-    
-    read(f6f)
-
-    #+ Ejemplo de error por asignacion incorrecta +#
-    #+ x = 10 +#
-
-    #+ Ejemplo de error por entero mayor a 64 bits +#
-    #+ x:= 18446744073709551616 +#
-
-    convDate(01-02-1900)
+    #+ Ejemplo de una variable mal declarada +#
+    #+ fecha : date +#
+    #+ h : foat +#
 }
+
+a1 := -125
+b2 := a1
+
+c33 := 5.34
+d4 := c33-2.1
+e5 := -5.1 #+ numero "negativo" +#
+
+f6f := "hola \n como estas"
+g := "que onda"
+
+#+ comentario +#
+
+if(a1 > b2) {
+    a1 := 10
+}
+else {
+    b2 := 20
+}
+
+while(c33 == 5.34 and d4 <= 2 < c33 or e5 >= 1) {
+    a1 := a1+1
+    if(not isZero(a1)) {
+        a1 := -125
+    }
+}
+
+write("hola")
+write(g)
+
+read(f6f)
+
+#+ Ejemplo de error por asignacion incorrecta +#
+#+ x = 10 +#
+
+#+ Ejemplo de error por entero mayor a 64 bits +#
+#+ x:= 18446744073709551616 +#
+
+convDate(01-02-1900)

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -15,8 +15,8 @@ use rustemo::debug::{log, logn};
 #[cfg(debug_assertions)]
 use rustemo::colored::*;
 pub type Input = str;
-const STATE_COUNT: usize = 114usize;
-const MAX_RECOGNIZERS: usize = 21usize;
+const STATE_COUNT: usize = 115usize;
+const MAX_RECOGNIZERS: usize = 22usize;
 #[allow(dead_code)]
 const TERMINAL_COUNT: usize = 40usize;
 #[allow(clippy::upper_case_acronyms)]
@@ -73,7 +73,8 @@ impl From<TokenKind> for usize {
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum ProdKind {
-    ProgramProgram,
+    ProgramProgramWithMain,
+    ProgramProgramOnlyBody,
     BodyBodyInitExpressions,
     BodyBodyInit,
     BodyBodyExpressions,
@@ -142,9 +143,10 @@ use ProdKind as PK;
 impl std::fmt::Debug for ProdKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
-            ProdKind::ProgramProgram => {
+            ProdKind::ProgramProgramWithMain => {
                 "Program: TokenId TokenParOpen TokenParClose TokenCBOpen Body TokenCBClose"
             }
+            ProdKind::ProgramProgramOnlyBody => "Program: Body",
             ProdKind::BodyBodyInitExpressions => "Body: TokenInit InitBody Expressions",
             ProdKind::BodyBodyInit => "Body: TokenInit InitBody",
             ProdKind::BodyBodyExpressions => "Body: Expressions",
@@ -307,7 +309,8 @@ pub enum NonTermKind {
 impl From<ProdKind> for NonTermKind {
     fn from(prod: ProdKind) -> Self {
         match prod {
-            ProdKind::ProgramProgram => NonTermKind::Program,
+            ProdKind::ProgramProgramWithMain => NonTermKind::Program,
+            ProdKind::ProgramProgramOnlyBody => NonTermKind::Program,
             ProdKind::BodyBodyInitExpressions => NonTermKind::Body,
             ProdKind::BodyBodyInit => NonTermKind::Body,
             ProdKind::BodyBodyExpressions => NonTermKind::Body,
@@ -414,99 +417,99 @@ pub enum State {
     #[default]
     AUGS0,
     TokenIdS1,
-    ProgramS2,
-    TokenParOpenS3,
-    TokenParCloseS4,
-    TokenCBOpenS5,
-    TokenIdS6,
-    TokenInitS7,
-    TokenWhileS8,
-    TokenIfS9,
-    TokenElseS10,
-    TokenReadS11,
-    TokenWriteS12,
-    TokenConvDateS13,
-    BodyS14,
-    FunctionReadS15,
-    FunctionWriteS16,
-    FunctionConvDateS17,
-    ExpressionsS18,
-    StatementS19,
-    AssignmentS20,
-    WhileLoopS21,
-    IfStatementS22,
-    ElseStatementS23,
-    TokenAssignS24,
-    TokenCBOpenS25,
-    InitBodyS26,
+    TokenInitS2,
+    TokenWhileS3,
+    TokenIfS4,
+    TokenElseS5,
+    TokenReadS6,
+    TokenWriteS7,
+    TokenConvDateS8,
+    ProgramS9,
+    BodyS10,
+    FunctionReadS11,
+    FunctionWriteS12,
+    FunctionConvDateS13,
+    ExpressionsS14,
+    StatementS15,
+    AssignmentS16,
+    WhileLoopS17,
+    IfStatementS18,
+    ElseStatementS19,
+    TokenAssignS20,
+    TokenParOpenS21,
+    TokenCBOpenS22,
+    InitBodyS23,
+    TokenParOpenS24,
+    TokenParOpenS25,
+    TokenCBOpenS26,
     TokenParOpenS27,
     TokenParOpenS28,
-    TokenCBOpenS29,
-    TokenParOpenS30,
-    TokenParOpenS31,
-    TokenParOpenS32,
-    TokenCBCloseS33,
-    ExpressionsS34,
-    TokenIntLiteralS35,
-    TokenFloatLiteralS36,
-    TokenStringLiteralS37,
-    TokenIdS38,
-    TokenSubS39,
-    TokenParOpenS40,
-    SimpleExpressionS41,
-    NumberS42,
-    ArithmeticExpressionS43,
-    TermS44,
-    FactorS45,
-    TokenIdS46,
-    VarDeclarationsS47,
-    VarDeclarationS48,
-    ExpressionsS49,
-    TokenTrueS50,
-    TokenFalseS51,
-    TokenNotS52,
-    TokenIsZeroS53,
-    FunctionIsZeroS54,
-    BooleanExpressionS55,
-    SimpleExpressionS56,
-    NotStatementS57,
-    BooleanExpressionS58,
-    BodyS59,
-    TokenIdS60,
-    SimpleExpressionS61,
-    TokenDateS62,
-    TokenIntLiteralS63,
-    TokenFloatLiteralS64,
-    ArithmeticExpressionS65,
-    TokenSumS66,
-    TokenSubS67,
-    TokenMulS68,
-    TokenDivS69,
-    TokenColonS70,
-    TokenCommaS71,
-    TokenCBCloseS72,
-    VarDeclarationsS73,
-    BooleanExpressionS74,
-    TokenParOpenS75,
-    TokenParCloseS76,
-    TokenEqualS77,
-    TokenNotEqualS78,
-    TokenLessS79,
-    TokenLessEqualS80,
-    TokenGreaterS81,
-    TokenGreaterEqualS82,
-    BooleanExpressionChainS83,
-    ComparisonOpS84,
-    TokenParCloseS85,
-    TokenCBCloseS86,
+    TokenParOpenS29,
+    TokenIdS30,
+    ExpressionsS31,
+    TokenIntLiteralS32,
+    TokenFloatLiteralS33,
+    TokenStringLiteralS34,
+    TokenIdS35,
+    TokenSubS36,
+    TokenParOpenS37,
+    SimpleExpressionS38,
+    NumberS39,
+    ArithmeticExpressionS40,
+    TermS41,
+    FactorS42,
+    TokenParCloseS43,
+    TokenIdS44,
+    VarDeclarationsS45,
+    VarDeclarationS46,
+    ExpressionsS47,
+    TokenTrueS48,
+    TokenFalseS49,
+    TokenNotS50,
+    TokenIsZeroS51,
+    FunctionIsZeroS52,
+    BooleanExpressionS53,
+    SimpleExpressionS54,
+    NotStatementS55,
+    BooleanExpressionS56,
+    BodyS57,
+    TokenIdS58,
+    SimpleExpressionS59,
+    TokenDateS60,
+    TokenIntLiteralS61,
+    TokenFloatLiteralS62,
+    ArithmeticExpressionS63,
+    TokenSumS64,
+    TokenSubS65,
+    TokenMulS66,
+    TokenDivS67,
+    TokenCBOpenS68,
+    TokenColonS69,
+    TokenCommaS70,
+    TokenCBCloseS71,
+    VarDeclarationsS72,
+    BooleanExpressionS73,
+    TokenParOpenS74,
+    TokenParCloseS75,
+    TokenEqualS76,
+    TokenNotEqualS77,
+    TokenLessS78,
+    TokenLessEqualS79,
+    TokenGreaterS80,
+    TokenGreaterEqualS81,
+    BooleanExpressionChainS82,
+    ComparisonOpS83,
+    TokenParCloseS84,
+    TokenCBCloseS85,
+    TokenParCloseS86,
     TokenParCloseS87,
     TokenParCloseS88,
     TokenParCloseS89,
-    TokenParCloseS90,
+    TermS90,
     TermS91,
-    TermS92,
+    FactorS92,
     FactorS93,
-    FactorS94,
+    BodyS94,
     TokenIntS95,
     TokenFloatS96,
     TokenStringS97,
@@ -519,13 +522,14 @@ pub enum State {
     ConjunctionS104,
     SimpleExpressionS105,
     TokenCBOpenS106,
-    TokenParCloseS107,
-    BodyS108,
-    BooleanExpressionS109,
-    BooleanExpressionChainS110,
-    BodyS111,
-    TokenCBCloseS112,
+    TokenCBCloseS107,
+    TokenParCloseS108,
+    BodyS109,
+    BooleanExpressionS110,
+    BooleanExpressionChainS111,
+    BodyS112,
     TokenCBCloseS113,
+    TokenCBCloseS114,
 }
 impl StateT for State {
     fn default_layout() -> Option<Self> {
@@ -542,99 +546,99 @@ impl std::fmt::Debug for State {
         let name = match self {
             State::AUGS0 => "0:AUG",
             State::TokenIdS1 => "1:TokenId",
-            State::ProgramS2 => "2:Program",
-            State::TokenParOpenS3 => "3:TokenParOpen",
-            State::TokenParCloseS4 => "4:TokenParClose",
-            State::TokenCBOpenS5 => "5:TokenCBOpen",
-            State::TokenIdS6 => "6:TokenId",
-            State::TokenInitS7 => "7:TokenInit",
-            State::TokenWhileS8 => "8:TokenWhile",
-            State::TokenIfS9 => "9:TokenIf",
-            State::TokenElseS10 => "10:TokenElse",
-            State::TokenReadS11 => "11:TokenRead",
-            State::TokenWriteS12 => "12:TokenWrite",
-            State::TokenConvDateS13 => "13:TokenConvDate",
-            State::BodyS14 => "14:Body",
-            State::FunctionReadS15 => "15:FunctionRead",
-            State::FunctionWriteS16 => "16:FunctionWrite",
-            State::FunctionConvDateS17 => "17:FunctionConvDate",
-            State::ExpressionsS18 => "18:Expressions",
-            State::StatementS19 => "19:Statement",
-            State::AssignmentS20 => "20:Assignment",
-            State::WhileLoopS21 => "21:WhileLoop",
-            State::IfStatementS22 => "22:IfStatement",
-            State::ElseStatementS23 => "23:ElseStatement",
-            State::TokenAssignS24 => "24:TokenAssign",
-            State::TokenCBOpenS25 => "25:TokenCBOpen",
-            State::InitBodyS26 => "26:InitBody",
+            State::TokenInitS2 => "2:TokenInit",
+            State::TokenWhileS3 => "3:TokenWhile",
+            State::TokenIfS4 => "4:TokenIf",
+            State::TokenElseS5 => "5:TokenElse",
+            State::TokenReadS6 => "6:TokenRead",
+            State::TokenWriteS7 => "7:TokenWrite",
+            State::TokenConvDateS8 => "8:TokenConvDate",
+            State::ProgramS9 => "9:Program",
+            State::BodyS10 => "10:Body",
+            State::FunctionReadS11 => "11:FunctionRead",
+            State::FunctionWriteS12 => "12:FunctionWrite",
+            State::FunctionConvDateS13 => "13:FunctionConvDate",
+            State::ExpressionsS14 => "14:Expressions",
+            State::StatementS15 => "15:Statement",
+            State::AssignmentS16 => "16:Assignment",
+            State::WhileLoopS17 => "17:WhileLoop",
+            State::IfStatementS18 => "18:IfStatement",
+            State::ElseStatementS19 => "19:ElseStatement",
+            State::TokenAssignS20 => "20:TokenAssign",
+            State::TokenParOpenS21 => "21:TokenParOpen",
+            State::TokenCBOpenS22 => "22:TokenCBOpen",
+            State::InitBodyS23 => "23:InitBody",
+            State::TokenParOpenS24 => "24:TokenParOpen",
+            State::TokenParOpenS25 => "25:TokenParOpen",
+            State::TokenCBOpenS26 => "26:TokenCBOpen",
             State::TokenParOpenS27 => "27:TokenParOpen",
             State::TokenParOpenS28 => "28:TokenParOpen",
-            State::TokenCBOpenS29 => "29:TokenCBOpen",
-            State::TokenParOpenS30 => "30:TokenParOpen",
-            State::TokenParOpenS31 => "31:TokenParOpen",
-            State::TokenParOpenS32 => "32:TokenParOpen",
-            State::TokenCBCloseS33 => "33:TokenCBClose",
-            State::ExpressionsS34 => "34:Expressions",
-            State::TokenIntLiteralS35 => "35:TokenIntLiteral",
-            State::TokenFloatLiteralS36 => "36:TokenFloatLiteral",
-            State::TokenStringLiteralS37 => "37:TokenStringLiteral",
-            State::TokenIdS38 => "38:TokenId",
-            State::TokenSubS39 => "39:TokenSub",
-            State::TokenParOpenS40 => "40:TokenParOpen",
-            State::SimpleExpressionS41 => "41:SimpleExpression",
-            State::NumberS42 => "42:Number",
-            State::ArithmeticExpressionS43 => "43:ArithmeticExpression",
-            State::TermS44 => "44:Term",
-            State::FactorS45 => "45:Factor",
-            State::TokenIdS46 => "46:TokenId",
-            State::VarDeclarationsS47 => "47:VarDeclarations",
-            State::VarDeclarationS48 => "48:VarDeclaration",
-            State::ExpressionsS49 => "49:Expressions",
-            State::TokenTrueS50 => "50:TokenTrue",
-            State::TokenFalseS51 => "51:TokenFalse",
-            State::TokenNotS52 => "52:TokenNot",
-            State::TokenIsZeroS53 => "53:TokenIsZero",
-            State::FunctionIsZeroS54 => "54:FunctionIsZero",
-            State::BooleanExpressionS55 => "55:BooleanExpression",
-            State::SimpleExpressionS56 => "56:SimpleExpression",
-            State::NotStatementS57 => "57:NotStatement",
-            State::BooleanExpressionS58 => "58:BooleanExpression",
-            State::BodyS59 => "59:Body",
-            State::TokenIdS60 => "60:TokenId",
-            State::SimpleExpressionS61 => "61:SimpleExpression",
-            State::TokenDateS62 => "62:TokenDate",
-            State::TokenIntLiteralS63 => "63:TokenIntLiteral",
-            State::TokenFloatLiteralS64 => "64:TokenFloatLiteral",
-            State::ArithmeticExpressionS65 => "65:ArithmeticExpression",
-            State::TokenSumS66 => "66:TokenSum",
-            State::TokenSubS67 => "67:TokenSub",
-            State::TokenMulS68 => "68:TokenMul",
-            State::TokenDivS69 => "69:TokenDiv",
-            State::TokenColonS70 => "70:TokenColon",
-            State::TokenCommaS71 => "71:TokenComma",
-            State::TokenCBCloseS72 => "72:TokenCBClose",
-            State::VarDeclarationsS73 => "73:VarDeclarations",
-            State::BooleanExpressionS74 => "74:BooleanExpression",
-            State::TokenParOpenS75 => "75:TokenParOpen",
-            State::TokenParCloseS76 => "76:TokenParClose",
-            State::TokenEqualS77 => "77:TokenEqual",
-            State::TokenNotEqualS78 => "78:TokenNotEqual",
-            State::TokenLessS79 => "79:TokenLess",
-            State::TokenLessEqualS80 => "80:TokenLessEqual",
-            State::TokenGreaterS81 => "81:TokenGreater",
-            State::TokenGreaterEqualS82 => "82:TokenGreaterEqual",
-            State::BooleanExpressionChainS83 => "83:BooleanExpressionChain",
-            State::ComparisonOpS84 => "84:ComparisonOp",
-            State::TokenParCloseS85 => "85:TokenParClose",
-            State::TokenCBCloseS86 => "86:TokenCBClose",
+            State::TokenParOpenS29 => "29:TokenParOpen",
+            State::TokenIdS30 => "30:TokenId",
+            State::ExpressionsS31 => "31:Expressions",
+            State::TokenIntLiteralS32 => "32:TokenIntLiteral",
+            State::TokenFloatLiteralS33 => "33:TokenFloatLiteral",
+            State::TokenStringLiteralS34 => "34:TokenStringLiteral",
+            State::TokenIdS35 => "35:TokenId",
+            State::TokenSubS36 => "36:TokenSub",
+            State::TokenParOpenS37 => "37:TokenParOpen",
+            State::SimpleExpressionS38 => "38:SimpleExpression",
+            State::NumberS39 => "39:Number",
+            State::ArithmeticExpressionS40 => "40:ArithmeticExpression",
+            State::TermS41 => "41:Term",
+            State::FactorS42 => "42:Factor",
+            State::TokenParCloseS43 => "43:TokenParClose",
+            State::TokenIdS44 => "44:TokenId",
+            State::VarDeclarationsS45 => "45:VarDeclarations",
+            State::VarDeclarationS46 => "46:VarDeclaration",
+            State::ExpressionsS47 => "47:Expressions",
+            State::TokenTrueS48 => "48:TokenTrue",
+            State::TokenFalseS49 => "49:TokenFalse",
+            State::TokenNotS50 => "50:TokenNot",
+            State::TokenIsZeroS51 => "51:TokenIsZero",
+            State::FunctionIsZeroS52 => "52:FunctionIsZero",
+            State::BooleanExpressionS53 => "53:BooleanExpression",
+            State::SimpleExpressionS54 => "54:SimpleExpression",
+            State::NotStatementS55 => "55:NotStatement",
+            State::BooleanExpressionS56 => "56:BooleanExpression",
+            State::BodyS57 => "57:Body",
+            State::TokenIdS58 => "58:TokenId",
+            State::SimpleExpressionS59 => "59:SimpleExpression",
+            State::TokenDateS60 => "60:TokenDate",
+            State::TokenIntLiteralS61 => "61:TokenIntLiteral",
+            State::TokenFloatLiteralS62 => "62:TokenFloatLiteral",
+            State::ArithmeticExpressionS63 => "63:ArithmeticExpression",
+            State::TokenSumS64 => "64:TokenSum",
+            State::TokenSubS65 => "65:TokenSub",
+            State::TokenMulS66 => "66:TokenMul",
+            State::TokenDivS67 => "67:TokenDiv",
+            State::TokenCBOpenS68 => "68:TokenCBOpen",
+            State::TokenColonS69 => "69:TokenColon",
+            State::TokenCommaS70 => "70:TokenComma",
+            State::TokenCBCloseS71 => "71:TokenCBClose",
+            State::VarDeclarationsS72 => "72:VarDeclarations",
+            State::BooleanExpressionS73 => "73:BooleanExpression",
+            State::TokenParOpenS74 => "74:TokenParOpen",
+            State::TokenParCloseS75 => "75:TokenParClose",
+            State::TokenEqualS76 => "76:TokenEqual",
+            State::TokenNotEqualS77 => "77:TokenNotEqual",
+            State::TokenLessS78 => "78:TokenLess",
+            State::TokenLessEqualS79 => "79:TokenLessEqual",
+            State::TokenGreaterS80 => "80:TokenGreater",
+            State::TokenGreaterEqualS81 => "81:TokenGreaterEqual",
+            State::BooleanExpressionChainS82 => "82:BooleanExpressionChain",
+            State::ComparisonOpS83 => "83:ComparisonOp",
+            State::TokenParCloseS84 => "84:TokenParClose",
+            State::TokenCBCloseS85 => "85:TokenCBClose",
+            State::TokenParCloseS86 => "86:TokenParClose",
             State::TokenParCloseS87 => "87:TokenParClose",
             State::TokenParCloseS88 => "88:TokenParClose",
             State::TokenParCloseS89 => "89:TokenParClose",
-            State::TokenParCloseS90 => "90:TokenParClose",
+            State::TermS90 => "90:Term",
             State::TermS91 => "91:Term",
-            State::TermS92 => "92:Term",
+            State::FactorS92 => "92:Factor",
             State::FactorS93 => "93:Factor",
-            State::FactorS94 => "94:Factor",
+            State::BodyS94 => "94:Body",
             State::TokenIntS95 => "95:TokenInt",
             State::TokenFloatS96 => "96:TokenFloat",
             State::TokenStringS97 => "97:TokenString",
@@ -647,13 +651,14 @@ impl std::fmt::Debug for State {
             State::ConjunctionS104 => "104:Conjunction",
             State::SimpleExpressionS105 => "105:SimpleExpression",
             State::TokenCBOpenS106 => "106:TokenCBOpen",
-            State::TokenParCloseS107 => "107:TokenParClose",
-            State::BodyS108 => "108:Body",
-            State::BooleanExpressionS109 => "109:BooleanExpression",
-            State::BooleanExpressionChainS110 => "110:BooleanExpressionChain",
-            State::BodyS111 => "111:Body",
-            State::TokenCBCloseS112 => "112:TokenCBClose",
+            State::TokenCBCloseS107 => "107:TokenCBClose",
+            State::TokenParCloseS108 => "108:TokenParClose",
+            State::BodyS109 => "109:Body",
+            State::BooleanExpressionS110 => "110:BooleanExpression",
+            State::BooleanExpressionChainS111 => "111:BooleanExpressionChain",
+            State::BodyS112 => "112:Body",
             State::TokenCBCloseS113 => "113:TokenCBClose",
+            State::TokenCBCloseS114 => "114:TokenCBClose",
         };
         write!(f, "{name}")
     }
@@ -742,104 +747,82 @@ pub struct GrammarParserDefinition {
 }
 fn action_aug_s0(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
         TK::TokenId => Vec::from(&[Shift(State::TokenIdS1)]),
+        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS2)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
         _ => vec![],
     }
 }
 fn action_tokenid_s1(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS3)]),
+        TK::TokenAssign => Vec::from(&[Shift(State::TokenAssignS20)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS21)]),
         _ => vec![],
     }
 }
-fn action_program_s2(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokeninit_s2(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::STOP => Vec::from(&[Accept]),
+        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS22)]),
         _ => vec![],
     }
 }
-fn action_tokenparopen_s3(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenwhile_s3(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS4)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS24)]),
         _ => vec![],
     }
 }
-fn action_tokenparclose_s4(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenif_s4(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS5)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS25)]),
         _ => vec![],
     }
 }
-fn action_tokencbopen_s5(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenelse_s5(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
-        TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
-        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS7)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS26)]),
         _ => vec![],
     }
 }
-fn action_tokenid_s6(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
-        TK::TokenAssign => Vec::from(&[Shift(State::TokenAssignS24)]),
-        _ => vec![],
-    }
-}
-fn action_tokeninit_s7(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
-        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS25)]),
-        _ => vec![],
-    }
-}
-fn action_tokenwhile_s8(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenread_s6(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS27)]),
         _ => vec![],
     }
 }
-fn action_tokenif_s9(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenwrite_s7(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS28)]),
         _ => vec![],
     }
 }
-fn action_tokenelse_s10(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenconvdate_s8(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS29)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS29)]),
         _ => vec![],
     }
 }
-fn action_tokenread_s11(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_program_s9(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS30)]),
+        TK::STOP => Vec::from(&[Accept]),
         _ => vec![],
     }
 }
-fn action_tokenwrite_s12(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_body_s10(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS31)]),
+        TK::STOP => Vec::from(&[Reduce(PK::ProgramProgramOnlyBody, 1usize)]),
         _ => vec![],
     }
 }
-fn action_tokenconvdate_s13(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_functionread_s11(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS32)]),
-        _ => vec![],
-    }
-}
-fn action_body_s14(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
-        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS33)]),
-        _ => vec![],
-    }
-}
-fn action_functionread_s15(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementRead, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementRead, 1usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::StatementStatementRead, 1usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::StatementStatementRead, 1usize)]),
@@ -851,8 +834,9 @@ fn action_functionread_s15(token_kind: TokenKind) -> Vec<Action<State, ProdKind>
         _ => vec![],
     }
 }
-fn action_functionwrite_s16(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_functionwrite_s12(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementWrite, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementWrite, 1usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::StatementStatementWrite, 1usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::StatementStatementWrite, 1usize)]),
@@ -864,8 +848,9 @@ fn action_functionwrite_s16(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_functionconvdate_s17(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_functionconvdate_s13(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementConvDate, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementConvDate, 1usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::StatementStatementConvDate, 1usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::StatementStatementConvDate, 1usize)]),
@@ -877,27 +862,30 @@ fn action_functionconvdate_s17(token_kind: TokenKind) -> Vec<Action<State, ProdK
         _ => vec![],
     }
 }
-fn action_expressions_s18(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_expressions_s14(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::BodyBodyExpressions, 1usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyExpressions, 1usize)]),
         _ => vec![],
     }
 }
-fn action_statement_s19(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_statement_s15(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
+        TK::STOP => Vec::from(&[Reduce(PK::ExpressionsExpressionSingle, 1usize)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::ExpressionsExpressionSingle, 1usize)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
         _ => vec![],
     }
 }
-fn action_assignment_s20(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_assignment_s16(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementAssignment, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementAssignment, 1usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::StatementStatementAssignment, 1usize)])
@@ -913,8 +901,9 @@ fn action_assignment_s20(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> 
         _ => vec![],
     }
 }
-fn action_whileloop_s21(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_whileloop_s17(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementWhile, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementWhile, 1usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::StatementStatementWhile, 1usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::StatementStatementWhile, 1usize)]),
@@ -926,8 +915,9 @@ fn action_whileloop_s21(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_ifstatement_s22(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_ifstatement_s18(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementIfStatement, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementIfStatement, 1usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::StatementStatementIfStatement, 1usize)])
@@ -943,8 +933,9 @@ fn action_ifstatement_s22(token_kind: TokenKind) -> Vec<Action<State, ProdKind>>
         _ => vec![],
     }
 }
-fn action_elsestatement_s23(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_elsestatement_s19(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::StatementStatementElseStatement, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::StatementStatementElseStatement, 1usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::StatementStatementElseStatement, 1usize)])
@@ -968,119 +959,128 @@ fn action_elsestatement_s23(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokenassign_s24(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenassign_s20(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokencbopen_s25(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparopen_s21(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS46)]),
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS43)]),
         _ => vec![],
     }
 }
-fn action_initbody_s26(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbopen_s22(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS44)]),
+        _ => vec![],
+    }
+}
+fn action_initbody_s23(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::BodyBodyInit, 2usize)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyInit, 2usize)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
+        _ => vec![],
+    }
+}
+fn action_tokenparopen_s24(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
+        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS48)]),
+        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS49)]),
+        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS50)]),
+        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS51)]),
+        _ => vec![],
+    }
+}
+fn action_tokenparopen_s25(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
+        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS48)]),
+        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS49)]),
+        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS50)]),
+        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS51)]),
+        _ => vec![],
+    }
+}
+fn action_tokencbopen_s26(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
+        TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
+        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS2)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
         _ => vec![],
     }
 }
 fn action_tokenparopen_s27(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
-        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS50)]),
-        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS51)]),
-        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS52)]),
-        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS53)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS58)]),
         _ => vec![],
     }
 }
 fn action_tokenparopen_s28(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
-        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS50)]),
-        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS51)]),
-        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS52)]),
-        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS53)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokencbopen_s29(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparopen_s29(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
-        TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
-        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS7)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenDate => Vec::from(&[Shift(State::TokenDateS60)]),
         _ => vec![],
     }
 }
-fn action_tokenparopen_s30(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenid_s30(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS60)]),
+        TK::TokenAssign => Vec::from(&[Shift(State::TokenAssignS20)]),
         _ => vec![],
     }
 }
-fn action_tokenparopen_s31(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_expressions_s31(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
-        _ => vec![],
-    }
-}
-fn action_tokenparopen_s32(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
-        TK::TokenDate => Vec::from(&[Shift(State::TokenDateS62)]),
-        _ => vec![],
-    }
-}
-fn action_tokencbclose_s33(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
-        TK::STOP => Vec::from(&[Reduce(PK::ProgramProgram, 6usize)]),
-        _ => vec![],
-    }
-}
-fn action_expressions_s34(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::ExpressionsExpressionRecursive, 2usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::ExpressionsExpressionRecursive, 2usize)])
         }
         _ => vec![],
     }
 }
-fn action_tokenintliteral_s35(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenintliteral_s32(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::NumberNumberInt, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::NumberNumberInt, 1usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::NumberNumberInt, 1usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::NumberNumberInt, 1usize)]),
@@ -1105,8 +1105,9 @@ fn action_tokenintliteral_s35(token_kind: TokenKind) -> Vec<Action<State, ProdKi
         _ => vec![],
     }
 }
-fn action_tokenfloatliteral_s36(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenfloatliteral_s33(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::NumberNumberFloat, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::NumberNumberFloat, 1usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::NumberNumberFloat, 1usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::NumberNumberFloat, 1usize)]),
@@ -1131,8 +1132,11 @@ fn action_tokenfloatliteral_s36(token_kind: TokenKind) -> Vec<Action<State, Prod
         _ => vec![],
     }
 }
-fn action_tokenstringliteral_s37(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenstringliteral_s34(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => {
+            Vec::from(&[Reduce(PK::SimpleExpressionSimpleExpressionString, 1usize)])
+        }
         TK::TokenId => {
             Vec::from(&[Reduce(PK::SimpleExpressionSimpleExpressionString, 1usize)])
         }
@@ -1187,8 +1191,9 @@ fn action_tokenstringliteral_s37(token_kind: TokenKind) -> Vec<Action<State, Pro
         _ => vec![],
     }
 }
-fn action_tokenid_s38(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenid_s35(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::FactorFactorId, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::FactorFactorId, 1usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::FactorFactorId, 1usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::FactorFactorId, 1usize)]),
@@ -1213,25 +1218,26 @@ fn action_tokenid_s38(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_tokensub_s39(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokensub_s36(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS63)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS64)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS61)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS62)]),
         _ => vec![],
     }
 }
-fn action_tokenparopen_s40(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparopen_s37(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_simpleexpression_s41(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_simpleexpression_s38(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::AssignmentAssignment, 3usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::AssignmentAssignment, 3usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::AssignmentAssignment, 3usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::AssignmentAssignment, 3usize)]),
@@ -1243,8 +1249,9 @@ fn action_simpleexpression_s41(token_kind: TokenKind) -> Vec<Action<State, ProdK
         _ => vec![],
     }
 }
-fn action_number_s42(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_number_s39(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::FactorFactorNumber, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::FactorFactorNumber, 1usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::FactorFactorNumber, 1usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::FactorFactorNumber, 1usize)]),
@@ -1269,15 +1276,18 @@ fn action_number_s42(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_arithmeticexpression_s43(
+fn action_arithmeticexpression_s40(
     token_kind: TokenKind,
 ) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => {
+            Vec::from(&[Reduce(PK::SimpleExpressionSimpleExpressionArithmetic, 1usize)])
+        }
         TK::TokenId => {
             Vec::from(&[Reduce(PK::SimpleExpressionSimpleExpressionArithmetic, 1usize)])
         }
-        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS66)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS67)]),
+        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS64)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS65)]),
         TK::TokenParClose => {
             Vec::from(&[Reduce(PK::SimpleExpressionSimpleExpressionArithmetic, 1usize)])
         }
@@ -1329,8 +1339,13 @@ fn action_arithmeticexpression_s43(
         _ => vec![],
     }
 }
-fn action_term_s44(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_term_s41(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionTerm, 1usize)],
+            )
+        }
         TK::TokenId => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionTerm, 1usize)],
@@ -1341,13 +1356,13 @@ fn action_term_s44(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionTerm, 1usize)],
             )
         }
-        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS68)]),
+        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS66)]),
         TK::TokenSub => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionTerm, 1usize)],
             )
         }
-        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS69)]),
+        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS67)]),
         TK::TokenParClose => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionTerm, 1usize)],
@@ -1431,8 +1446,9 @@ fn action_term_s44(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_factor_s45(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_factor_s42(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::TermTermFactor, 1usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::TermTermFactor, 1usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::TermTermFactor, 1usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::TermTermFactor, 1usize)]),
@@ -1457,35 +1473,42 @@ fn action_factor_s45(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_tokenid_s46(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s43(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenColon => Vec::from(&[Shift(State::TokenColonS70)]),
-        TK::TokenComma => Vec::from(&[Shift(State::TokenCommaS71)]),
+        TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS68)]),
         _ => vec![],
     }
 }
-fn action_vardeclarations_s47(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenid_s44(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS72)]),
+        TK::TokenColon => Vec::from(&[Shift(State::TokenColonS69)]),
+        TK::TokenComma => Vec::from(&[Shift(State::TokenCommaS70)]),
         _ => vec![],
     }
 }
-fn action_vardeclaration_s48(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_vardeclarations_s45(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS46)]),
+        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS71)]),
+        _ => vec![],
+    }
+}
+fn action_vardeclaration_s46(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS44)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::VarDeclarationsVarDeclarationsSingle, 1usize)])
         }
         _ => vec![],
     }
 }
-fn action_expressions_s49(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_expressions_s47(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::BodyBodyInitExpressions, 3usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyInitExpressions, 3usize)]),
         _ => vec![],
     }
 }
-fn action_tokentrue_s50(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokentrue_s48(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(&[Reduce(PK::BooleanExpressionBooleanExpressionTrue, 1usize)])
@@ -1493,7 +1516,7 @@ fn action_tokentrue_s50(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_tokenfalse_s51(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenfalse_s49(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(&[Reduce(PK::BooleanExpressionBooleanExpressionFalse, 1usize)])
@@ -1501,28 +1524,28 @@ fn action_tokenfalse_s51(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> 
         _ => vec![],
     }
 }
-fn action_tokennot_s52(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokennot_s50(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
-        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS50)]),
-        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS51)]),
-        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS52)]),
-        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS53)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
+        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS48)]),
+        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS49)]),
+        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS50)]),
+        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS51)]),
         _ => vec![],
     }
 }
-fn action_tokeniszero_s53(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokeniszero_s51(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS75)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS74)]),
         _ => vec![],
     }
 }
-fn action_functioniszero_s54(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_functioniszero_s52(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(&[Reduce(PK::BooleanExpressionBooleanExpressionIsZero, 1usize)])
@@ -1530,25 +1553,25 @@ fn action_functioniszero_s54(token_kind: TokenKind) -> Vec<Action<State, ProdKin
         _ => vec![],
     }
 }
-fn action_booleanexpression_s55(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_booleanexpression_s53(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS76)]),
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS75)]),
         _ => vec![],
     }
 }
-fn action_simpleexpression_s56(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_simpleexpression_s54(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(
                 &[Reduce(PK::BooleanExpressionChainBooleanExpressionChainEmpty, 0usize)],
             )
         }
-        TK::TokenEqual => Vec::from(&[Shift(State::TokenEqualS77)]),
-        TK::TokenNotEqual => Vec::from(&[Shift(State::TokenNotEqualS78)]),
-        TK::TokenLess => Vec::from(&[Shift(State::TokenLessS79)]),
-        TK::TokenLessEqual => Vec::from(&[Shift(State::TokenLessEqualS80)]),
-        TK::TokenGreater => Vec::from(&[Shift(State::TokenGreaterS81)]),
-        TK::TokenGreaterEqual => Vec::from(&[Shift(State::TokenGreaterEqualS82)]),
+        TK::TokenEqual => Vec::from(&[Shift(State::TokenEqualS76)]),
+        TK::TokenNotEqual => Vec::from(&[Shift(State::TokenNotEqualS77)]),
+        TK::TokenLess => Vec::from(&[Shift(State::TokenLessS78)]),
+        TK::TokenLessEqual => Vec::from(&[Shift(State::TokenLessEqualS79)]),
+        TK::TokenGreater => Vec::from(&[Shift(State::TokenGreaterS80)]),
+        TK::TokenGreaterEqual => Vec::from(&[Shift(State::TokenGreaterEqualS81)]),
         TK::TokenAnd => {
             Vec::from(
                 &[Reduce(PK::BooleanExpressionChainBooleanExpressionChainEmpty, 0usize)],
@@ -1562,7 +1585,7 @@ fn action_simpleexpression_s56(token_kind: TokenKind) -> Vec<Action<State, ProdK
         _ => vec![],
     }
 }
-fn action_notstatement_s57(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_notstatement_s55(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(
@@ -1572,38 +1595,39 @@ fn action_notstatement_s57(token_kind: TokenKind) -> Vec<Action<State, ProdKind>
         _ => vec![],
     }
 }
-fn action_booleanexpression_s58(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_booleanexpression_s56(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS85)]),
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS84)]),
         _ => vec![],
     }
 }
-fn action_body_s59(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_body_s57(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS86)]),
+        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS85)]),
         _ => vec![],
     }
 }
-fn action_tokenid_s60(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenid_s58(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS86)]),
+        _ => vec![],
+    }
+}
+fn action_simpleexpression_s59(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS87)]),
         _ => vec![],
     }
 }
-fn action_simpleexpression_s61(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokendate_s60(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS88)]),
         _ => vec![],
     }
 }
-fn action_tokendate_s62(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenintliteral_s61(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS89)]),
-        _ => vec![],
-    }
-}
-fn action_tokenintliteral_s63(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::NumberNumberNegativeInt, 2usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::NumberNumberNegativeInt, 2usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::NumberNumberNegativeInt, 2usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::NumberNumberNegativeInt, 2usize)]),
@@ -1630,8 +1654,9 @@ fn action_tokenintliteral_s63(token_kind: TokenKind) -> Vec<Action<State, ProdKi
         _ => vec![],
     }
 }
-fn action_tokenfloatliteral_s64(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenfloatliteral_s62(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::NumberNumberNegativeFloat, 2usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::NumberNumberNegativeFloat, 2usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::NumberNumberNegativeFloat, 2usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::NumberNumberNegativeFloat, 2usize)]),
@@ -1658,57 +1683,71 @@ fn action_tokenfloatliteral_s64(token_kind: TokenKind) -> Vec<Action<State, Prod
         _ => vec![],
     }
 }
-fn action_arithmeticexpression_s65(
+fn action_arithmeticexpression_s63(
     token_kind: TokenKind,
 ) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS66)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS67)]),
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS90)]),
+        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS64)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS65)]),
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS89)]),
         _ => vec![],
     }
 }
-fn action_tokensum_s66(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokensum_s64(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokensub_s67(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokensub_s65(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokenmul_s68(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenmul_s66(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokendiv_s69(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokendiv_s67(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokencolon_s70(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbopen_s68(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
+        TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
+        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS2)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
+        _ => vec![],
+    }
+}
+fn action_tokencolon_s69(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenInt => Vec::from(&[Shift(State::TokenIntS95)]),
         TK::TokenFloat => Vec::from(&[Shift(State::TokenFloatS96)]),
@@ -1716,14 +1755,15 @@ fn action_tokencolon_s70(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> 
         _ => vec![],
     }
 }
-fn action_tokencomma_s71(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencomma_s70(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS46)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS44)]),
         _ => vec![],
     }
 }
-fn action_tokencbclose_s72(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbclose_s71(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::InitBodyInitBody, 3usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::InitBodyInitBody, 3usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::InitBodyInitBody, 3usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::InitBodyInitBody, 3usize)]),
@@ -1735,7 +1775,7 @@ fn action_tokencbclose_s72(token_kind: TokenKind) -> Vec<Action<State, ProdKind>
         _ => vec![],
     }
 }
-fn action_vardeclarations_s73(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_vardeclarations_s72(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::VarDeclarationsVarDeclarationsRecursive, 2usize)])
@@ -1743,29 +1783,29 @@ fn action_vardeclarations_s73(token_kind: TokenKind) -> Vec<Action<State, ProdKi
         _ => vec![],
     }
 }
-fn action_booleanexpression_s74(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_booleanexpression_s73(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => Vec::from(&[Reduce(PK::NotStatementNot, 2usize)]),
         _ => vec![],
     }
 }
-fn action_tokenparopen_s75(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparopen_s74(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokenparclose_s76(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s75(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS101)]),
         _ => vec![],
     }
 }
-fn action_tokenequal_s77(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenequal_s76(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpEqual, 1usize)])
@@ -1784,7 +1824,7 @@ fn action_tokenequal_s77(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> 
         _ => vec![],
     }
 }
-fn action_tokennotequal_s78(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokennotequal_s77(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpNotEqual, 1usize)])
@@ -1805,7 +1845,7 @@ fn action_tokennotequal_s78(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokenless_s79(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenless_s78(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpLess, 1usize)])
@@ -1824,7 +1864,7 @@ fn action_tokenless_s79(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_tokenlessequal_s80(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenlessequal_s79(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpLessEqual, 1usize)])
@@ -1847,7 +1887,7 @@ fn action_tokenlessequal_s80(token_kind: TokenKind) -> Vec<Action<State, ProdKin
         _ => vec![],
     }
 }
-fn action_tokengreater_s81(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokengreater_s80(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpGreater, 1usize)])
@@ -1866,7 +1906,7 @@ fn action_tokengreater_s81(token_kind: TokenKind) -> Vec<Action<State, ProdKind>
         _ => vec![],
     }
 }
-fn action_tokengreaterequal_s82(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokengreaterequal_s81(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenIntLiteral => {
             Vec::from(&[Reduce(PK::ComparisonOpComparisonOpGreaterEqual, 1usize)])
@@ -1889,7 +1929,7 @@ fn action_tokengreaterequal_s82(token_kind: TokenKind) -> Vec<Action<State, Prod
         _ => vec![],
     }
 }
-fn action_booleanexpressionchain_s83(
+fn action_booleanexpressionchain_s82(
     token_kind: TokenKind,
 ) -> Vec<Action<State, ProdKind>> {
     match token_kind {
@@ -1903,25 +1943,26 @@ fn action_booleanexpressionchain_s83(
         _ => vec![],
     }
 }
-fn action_comparisonop_s84(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_comparisonop_s83(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
         _ => vec![],
     }
 }
-fn action_tokenparclose_s85(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s84(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenCBOpen => Vec::from(&[Shift(State::TokenCBOpenS106)]),
         _ => vec![],
     }
 }
-fn action_tokencbclose_s86(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbclose_s85(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::ElseStatementElseStatement, 4usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::ElseStatementElseStatement, 4usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::ElseStatementElseStatement, 4usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::ElseStatementElseStatement, 4usize)]),
@@ -1933,8 +1974,9 @@ fn action_tokencbclose_s86(token_kind: TokenKind) -> Vec<Action<State, ProdKind>
         _ => vec![],
     }
 }
-fn action_tokenparclose_s87(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s86(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::FunctionReadFunctionReadCall, 4usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::FunctionReadFunctionReadCall, 4usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::FunctionReadFunctionReadCall, 4usize)])
@@ -1950,8 +1992,9 @@ fn action_tokenparclose_s87(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokenparclose_s88(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s87(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::FunctionWriteFunctionWriteCall, 4usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::FunctionWriteFunctionWriteCall, 4usize)]),
         TK::TokenCBClose => {
             Vec::from(&[Reduce(PK::FunctionWriteFunctionWriteCall, 4usize)])
@@ -1971,8 +2014,13 @@ fn action_tokenparclose_s88(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokenparclose_s89(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s88(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => {
+            Vec::from(
+                &[Reduce(PK::FunctionConvDateFunctionConvDateVariableCall, 4usize)],
+            )
+        }
         TK::TokenId => {
             Vec::from(
                 &[Reduce(PK::FunctionConvDateFunctionConvDateVariableCall, 4usize)],
@@ -2016,8 +2064,9 @@ fn action_tokenparclose_s89(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokenparclose_s90(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokenparclose_s89(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::FactorFactorParen, 3usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::FactorFactorParen, 3usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::FactorFactorParen, 3usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::FactorFactorParen, 3usize)]),
@@ -2042,110 +2091,120 @@ fn action_tokenparclose_s90(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
+fn action_term_s90(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::STOP => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenId => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenSum => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS66)]),
+        TK::TokenSub => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS67)]),
+        TK::TokenParClose => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenCBClose => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenWhile => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenEqual => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenNotEqual => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenLess => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenLessEqual => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenGreater => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenGreaterEqual => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenIf => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenElse => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenAnd => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenOr => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenRead => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenWrite => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        TK::TokenConvDate => {
+            Vec::from(
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+            )
+        }
+        _ => vec![],
+    }
+}
 fn action_term_s91(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => {
+        TK::STOP => {
             Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
+                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSubTerm, 3usize)],
             )
         }
-        TK::TokenSum => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS68)]),
-        TK::TokenSub => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS69)]),
-        TK::TokenParClose => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenCBClose => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenWhile => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenEqual => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenNotEqual => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenLess => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenLessEqual => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenGreater => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenGreaterEqual => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenIf => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenElse => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenAnd => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenOr => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenRead => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenWrite => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        TK::TokenConvDate => {
-            Vec::from(
-                &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSumTerm, 3usize)],
-            )
-        }
-        _ => vec![],
-    }
-}
-fn action_term_s92(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
-    match token_kind {
         TK::TokenId => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSubTerm, 3usize)],
@@ -2156,13 +2215,13 @@ fn action_term_s92(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSubTerm, 3usize)],
             )
         }
-        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS68)]),
+        TK::TokenMul => Vec::from(&[Shift(State::TokenMulS66)]),
         TK::TokenSub => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSubTerm, 3usize)],
             )
         }
-        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS69)]),
+        TK::TokenDiv => Vec::from(&[Shift(State::TokenDivS67)]),
         TK::TokenParClose => {
             Vec::from(
                 &[Reduce(PK::ArithmeticExpressionArithmeticExpressionSubTerm, 3usize)],
@@ -2246,8 +2305,9 @@ fn action_term_s92(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_factor_s93(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_factor_s92(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::TermTermMulFactor, 3usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::TermTermMulFactor, 3usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::TermTermMulFactor, 3usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::TermTermMulFactor, 3usize)]),
@@ -2272,8 +2332,9 @@ fn action_factor_s93(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         _ => vec![],
     }
 }
-fn action_factor_s94(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_factor_s93(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
         TK::TokenSum => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
         TK::TokenMul => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
@@ -2295,6 +2356,12 @@ fn action_factor_s94(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
         TK::TokenRead => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
         TK::TokenWrite => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
         TK::TokenConvDate => Vec::from(&[Reduce(PK::TermTermDivFactor, 3usize)]),
+        _ => vec![],
+    }
+}
+fn action_body_s94(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS107)]),
         _ => vec![],
     }
 }
@@ -2345,23 +2412,23 @@ fn action_arithmeticexpression_s100(
     token_kind: TokenKind,
 ) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS66)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS67)]),
-        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS107)]),
+        TK::TokenSum => Vec::from(&[Shift(State::TokenSumS64)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS65)]),
+        TK::TokenParClose => Vec::from(&[Shift(State::TokenParCloseS108)]),
         _ => vec![],
     }
 }
 fn action_tokencbopen_s101(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
-        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS7)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS2)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
         _ => vec![],
     }
 }
@@ -2407,16 +2474,16 @@ fn action_tokenor_s103(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
 }
 fn action_conjunction_s104(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS35)]),
-        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS36)]),
-        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS37)]),
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS38)]),
-        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS39)]),
-        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS40)]),
-        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS50)]),
-        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS51)]),
-        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS52)]),
-        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS53)]),
+        TK::TokenIntLiteral => Vec::from(&[Shift(State::TokenIntLiteralS32)]),
+        TK::TokenFloatLiteral => Vec::from(&[Shift(State::TokenFloatLiteralS33)]),
+        TK::TokenStringLiteral => Vec::from(&[Shift(State::TokenStringLiteralS34)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS35)]),
+        TK::TokenSub => Vec::from(&[Shift(State::TokenSubS36)]),
+        TK::TokenParOpen => Vec::from(&[Shift(State::TokenParOpenS37)]),
+        TK::TokenTrue => Vec::from(&[Shift(State::TokenTrueS48)]),
+        TK::TokenFalse => Vec::from(&[Shift(State::TokenFalseS49)]),
+        TK::TokenNot => Vec::from(&[Shift(State::TokenNotS50)]),
+        TK::TokenIsZero => Vec::from(&[Shift(State::TokenIsZeroS51)]),
         _ => vec![],
     }
 }
@@ -2427,12 +2494,12 @@ fn action_simpleexpression_s105(token_kind: TokenKind) -> Vec<Action<State, Prod
                 &[Reduce(PK::BooleanExpressionChainBooleanExpressionChainEmpty, 0usize)],
             )
         }
-        TK::TokenEqual => Vec::from(&[Shift(State::TokenEqualS77)]),
-        TK::TokenNotEqual => Vec::from(&[Shift(State::TokenNotEqualS78)]),
-        TK::TokenLess => Vec::from(&[Shift(State::TokenLessS79)]),
-        TK::TokenLessEqual => Vec::from(&[Shift(State::TokenLessEqualS80)]),
-        TK::TokenGreater => Vec::from(&[Shift(State::TokenGreaterS81)]),
-        TK::TokenGreaterEqual => Vec::from(&[Shift(State::TokenGreaterEqualS82)]),
+        TK::TokenEqual => Vec::from(&[Shift(State::TokenEqualS76)]),
+        TK::TokenNotEqual => Vec::from(&[Shift(State::TokenNotEqualS77)]),
+        TK::TokenLess => Vec::from(&[Shift(State::TokenLessS78)]),
+        TK::TokenLessEqual => Vec::from(&[Shift(State::TokenLessEqualS79)]),
+        TK::TokenGreater => Vec::from(&[Shift(State::TokenGreaterS80)]),
+        TK::TokenGreaterEqual => Vec::from(&[Shift(State::TokenGreaterEqualS81)]),
         TK::TokenAnd => {
             Vec::from(
                 &[Reduce(PK::BooleanExpressionChainBooleanExpressionChainEmpty, 0usize)],
@@ -2448,19 +2515,25 @@ fn action_simpleexpression_s105(token_kind: TokenKind) -> Vec<Action<State, Prod
 }
 fn action_tokencbopen_s106(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenId => Vec::from(&[Shift(State::TokenIdS6)]),
+        TK::TokenId => Vec::from(&[Shift(State::TokenIdS30)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::BodyBodyEmpty, 0usize)]),
-        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS7)]),
-        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS8)]),
-        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS9)]),
-        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS10)]),
-        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS11)]),
-        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS12)]),
-        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS13)]),
+        TK::TokenInit => Vec::from(&[Shift(State::TokenInitS2)]),
+        TK::TokenWhile => Vec::from(&[Shift(State::TokenWhileS3)]),
+        TK::TokenIf => Vec::from(&[Shift(State::TokenIfS4)]),
+        TK::TokenElse => Vec::from(&[Shift(State::TokenElseS5)]),
+        TK::TokenRead => Vec::from(&[Shift(State::TokenReadS6)]),
+        TK::TokenWrite => Vec::from(&[Shift(State::TokenWriteS7)]),
+        TK::TokenConvDate => Vec::from(&[Shift(State::TokenConvDateS8)]),
         _ => vec![],
     }
 }
-fn action_tokenparclose_s107(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbclose_s107(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+    match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::ProgramProgramWithMain, 6usize)]),
+        _ => vec![],
+    }
+}
+fn action_tokenparclose_s108(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(&[Reduce(PK::FunctionIsZeroFunctionIsZeroCall, 4usize)])
@@ -2468,13 +2541,13 @@ fn action_tokenparclose_s107(token_kind: TokenKind) -> Vec<Action<State, ProdKin
         _ => vec![],
     }
 }
-fn action_body_s108(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_body_s109(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS112)]),
+        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS113)]),
         _ => vec![],
     }
 }
-fn action_booleanexpression_s109(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_booleanexpression_s110(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
         TK::TokenParClose => {
             Vec::from(
@@ -2489,7 +2562,7 @@ fn action_booleanexpression_s109(token_kind: TokenKind) -> Vec<Action<State, Pro
         _ => vec![],
     }
 }
-fn action_booleanexpressionchain_s110(
+fn action_booleanexpressionchain_s111(
     token_kind: TokenKind,
 ) -> Vec<Action<State, ProdKind>> {
     match token_kind {
@@ -2511,14 +2584,15 @@ fn action_booleanexpressionchain_s110(
         _ => vec![],
     }
 }
-fn action_body_s111(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_body_s112(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
-        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS113)]),
+        TK::TokenCBClose => Vec::from(&[Shift(State::TokenCBCloseS114)]),
         _ => vec![],
     }
 }
-fn action_tokencbclose_s112(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbclose_s113(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::WhileLoopWhile, 7usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::WhileLoopWhile, 7usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::WhileLoopWhile, 7usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::WhileLoopWhile, 7usize)]),
@@ -2530,8 +2604,9 @@ fn action_tokencbclose_s112(token_kind: TokenKind) -> Vec<Action<State, ProdKind
         _ => vec![],
     }
 }
-fn action_tokencbclose_s113(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
+fn action_tokencbclose_s114(token_kind: TokenKind) -> Vec<Action<State, ProdKind>> {
     match token_kind {
+        TK::STOP => Vec::from(&[Reduce(PK::IfStatementIfStatement, 7usize)]),
         TK::TokenId => Vec::from(&[Reduce(PK::IfStatementIfStatement, 7usize)]),
         TK::TokenCBClose => Vec::from(&[Reduce(PK::IfStatementIfStatement, 7usize)]),
         TK::TokenWhile => Vec::from(&[Reduce(PK::IfStatementIfStatement, 7usize)]),
@@ -2545,7 +2620,17 @@ fn action_tokencbclose_s113(token_kind: TokenKind) -> Vec<Action<State, ProdKind
 }
 fn goto_aug_s0(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Program => State::ProgramS2,
+        NonTermKind::Program => State::ProgramS9,
+        NonTermKind::Body => State::BodyS10,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS14,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2554,130 +2639,145 @@ fn goto_aug_s0(nonterm_kind: NonTermKind) -> State {
         }
     }
 }
-fn goto_tokencbopen_s5(nonterm_kind: NonTermKind) -> State {
+fn goto_tokeninit_s2(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Body => State::BodyS14,
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS18,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::InitBody => State::InitBodyS23,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenCBOpenS5
+                State::TokenInitS2
             )
         }
     }
 }
-fn goto_tokeninit_s7(nonterm_kind: NonTermKind) -> State {
+fn goto_statement_s15(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::InitBody => State::InitBodyS26,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS31,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenInitS7
+                State::StatementS15
             )
         }
     }
 }
-fn goto_statement_s19(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenassign_s20(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS34,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS38,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::StatementS19
+                State::TokenAssignS20
             )
         }
     }
 }
-fn goto_tokenassign_s24(nonterm_kind: NonTermKind) -> State {
+fn goto_tokencbopen_s22(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::SimpleExpression => State::SimpleExpressionS41,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::VarDeclarations => State::VarDeclarationsS45,
+        NonTermKind::VarDeclaration => State::VarDeclarationS46,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenAssignS24
+                State::TokenCBOpenS22
             )
         }
     }
 }
-fn goto_tokencbopen_s25(nonterm_kind: NonTermKind) -> State {
+fn goto_initbody_s23(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::VarDeclarations => State::VarDeclarationsS47,
-        NonTermKind::VarDeclaration => State::VarDeclarationS48,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS47,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenCBOpenS25
+                State::InitBodyS23
             )
         }
     }
 }
-fn goto_initbody_s26(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenparopen_s24(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS49,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::FunctionIsZero => State::FunctionIsZeroS52,
+        NonTermKind::BooleanExpression => State::BooleanExpressionS53,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS54,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::NotStatement => State::NotStatementS55,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::InitBodyS26
+                State::TokenParOpenS24
             )
         }
     }
 }
-fn goto_tokenparopen_s27(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenparopen_s25(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionIsZero => State::FunctionIsZeroS54,
-        NonTermKind::BooleanExpression => State::BooleanExpressionS55,
-        NonTermKind::SimpleExpression => State::SimpleExpressionS56,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::NotStatement => State::NotStatementS57,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::FunctionIsZero => State::FunctionIsZeroS52,
+        NonTermKind::BooleanExpression => State::BooleanExpressionS56,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS54,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::NotStatement => State::NotStatementS55,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenParOpenS27
+                State::TokenParOpenS25
+            )
+        }
+    }
+}
+fn goto_tokencbopen_s26(nonterm_kind: NonTermKind) -> State {
+    match nonterm_kind {
+        NonTermKind::Body => State::BodyS57,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS14,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
+        _ => {
+            panic!(
+                "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
+                State::TokenCBOpenS26
             )
         }
     }
 }
 fn goto_tokenparopen_s28(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionIsZero => State::FunctionIsZeroS54,
-        NonTermKind::BooleanExpression => State::BooleanExpressionS58,
-        NonTermKind::SimpleExpression => State::SimpleExpressionS56,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::NotStatement => State::NotStatementS57,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS59,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2686,221 +2786,206 @@ fn goto_tokenparopen_s28(nonterm_kind: NonTermKind) -> State {
         }
     }
 }
-fn goto_tokencbopen_s29(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenparopen_s37(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Body => State::BodyS59,
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS18,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS63,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenCBOpenS29
+                State::TokenParOpenS37
             )
         }
     }
 }
-fn goto_tokenparopen_s31(nonterm_kind: NonTermKind) -> State {
+fn goto_vardeclaration_s46(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::SimpleExpression => State::SimpleExpressionS61,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::VarDeclarations => State::VarDeclarationsS72,
+        NonTermKind::VarDeclaration => State::VarDeclarationS46,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenParOpenS31
+                State::VarDeclarationS46
             )
         }
     }
 }
-fn goto_tokenparopen_s40(nonterm_kind: NonTermKind) -> State {
+fn goto_tokennot_s50(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS65,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::FunctionIsZero => State::FunctionIsZeroS52,
+        NonTermKind::BooleanExpression => State::BooleanExpressionS73,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS54,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::NotStatement => State::NotStatementS55,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenParOpenS40
+                State::TokenNotS50
             )
         }
     }
 }
-fn goto_vardeclaration_s48(nonterm_kind: NonTermKind) -> State {
+fn goto_simpleexpression_s54(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::VarDeclarations => State::VarDeclarationsS73,
-        NonTermKind::VarDeclaration => State::VarDeclarationS48,
+        NonTermKind::BooleanExpressionChain => State::BooleanExpressionChainS82,
+        NonTermKind::ComparisonOp => State::ComparisonOpS83,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::VarDeclarationS48
+                State::SimpleExpressionS54
             )
         }
     }
 }
-fn goto_tokennot_s52(nonterm_kind: NonTermKind) -> State {
+fn goto_tokensum_s64(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionIsZero => State::FunctionIsZeroS54,
-        NonTermKind::BooleanExpression => State::BooleanExpressionS74,
-        NonTermKind::SimpleExpression => State::SimpleExpressionS56,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::NotStatement => State::NotStatementS57,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::Term => State::TermS90,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenNotS52
+                State::TokenSumS64
             )
         }
     }
 }
-fn goto_simpleexpression_s56(nonterm_kind: NonTermKind) -> State {
+fn goto_tokensub_s65(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::BooleanExpressionChain => State::BooleanExpressionChainS83,
-        NonTermKind::ComparisonOp => State::ComparisonOpS84,
-        _ => {
-            panic!(
-                "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::SimpleExpressionS56
-            )
-        }
-    }
-}
-fn goto_tokensum_s66(nonterm_kind: NonTermKind) -> State {
-    match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
+        NonTermKind::Number => State::NumberS39,
         NonTermKind::Term => State::TermS91,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenSumS66
+                State::TokenSubS65
             )
         }
     }
 }
-fn goto_tokensub_s67(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenmul_s66(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::Term => State::TermS92,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::Factor => State::FactorS92,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenSubS67
+                State::TokenMulS66
             )
         }
     }
 }
-fn goto_tokenmul_s68(nonterm_kind: NonTermKind) -> State {
+fn goto_tokendiv_s67(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
+        NonTermKind::Number => State::NumberS39,
         NonTermKind::Factor => State::FactorS93,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenMulS68
+                State::TokenDivS67
             )
         }
     }
 }
-fn goto_tokendiv_s69(nonterm_kind: NonTermKind) -> State {
+fn goto_tokencbopen_s68(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::Factor => State::FactorS94,
+        NonTermKind::Body => State::BodyS94,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS14,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenDivS69
+                State::TokenCBOpenS68
             )
         }
     }
 }
-fn goto_tokencolon_s70(nonterm_kind: NonTermKind) -> State {
+fn goto_tokencolon_s69(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
         NonTermKind::DataType => State::DataTypeS98,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenColonS70
+                State::TokenColonS69
             )
         }
     }
 }
-fn goto_tokencomma_s71(nonterm_kind: NonTermKind) -> State {
+fn goto_tokencomma_s70(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
         NonTermKind::VarDeclaration => State::VarDeclarationS99,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenCommaS71
+                State::TokenCommaS70
             )
         }
     }
 }
-fn goto_tokenparopen_s75(nonterm_kind: NonTermKind) -> State {
+fn goto_tokenparopen_s74(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Number => State::NumberS42,
+        NonTermKind::Number => State::NumberS39,
         NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS100,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::TokenParOpenS75
+                State::TokenParOpenS74
             )
         }
     }
 }
-fn goto_booleanexpressionchain_s83(nonterm_kind: NonTermKind) -> State {
+fn goto_booleanexpressionchain_s82(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
         NonTermKind::Conjunction => State::ConjunctionS104,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::BooleanExpressionChainS83
+                State::BooleanExpressionChainS82
             )
         }
     }
 }
-fn goto_comparisonop_s84(nonterm_kind: NonTermKind) -> State {
+fn goto_comparisonop_s83(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
         NonTermKind::SimpleExpression => State::SimpleExpressionS105,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
-                State::ComparisonOpS84
+                State::ComparisonOpS83
             )
         }
     }
 }
 fn goto_tokencbopen_s101(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Body => State::BodyS108,
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS18,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::Body => State::BodyS109,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS14,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2911,14 +2996,14 @@ fn goto_tokencbopen_s101(nonterm_kind: NonTermKind) -> State {
 }
 fn goto_conjunction_s104(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::FunctionIsZero => State::FunctionIsZeroS54,
-        NonTermKind::BooleanExpression => State::BooleanExpressionS109,
-        NonTermKind::SimpleExpression => State::SimpleExpressionS56,
-        NonTermKind::Number => State::NumberS42,
-        NonTermKind::NotStatement => State::NotStatementS57,
-        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS43,
-        NonTermKind::Term => State::TermS44,
-        NonTermKind::Factor => State::FactorS45,
+        NonTermKind::FunctionIsZero => State::FunctionIsZeroS52,
+        NonTermKind::BooleanExpression => State::BooleanExpressionS110,
+        NonTermKind::SimpleExpression => State::SimpleExpressionS54,
+        NonTermKind::Number => State::NumberS39,
+        NonTermKind::NotStatement => State::NotStatementS55,
+        NonTermKind::ArithmeticExpression => State::ArithmeticExpressionS40,
+        NonTermKind::Term => State::TermS41,
+        NonTermKind::Factor => State::FactorS42,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2929,8 +3014,8 @@ fn goto_conjunction_s104(nonterm_kind: NonTermKind) -> State {
 }
 fn goto_simpleexpression_s105(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::BooleanExpressionChain => State::BooleanExpressionChainS110,
-        NonTermKind::ComparisonOp => State::ComparisonOpS84,
+        NonTermKind::BooleanExpressionChain => State::BooleanExpressionChainS111,
+        NonTermKind::ComparisonOp => State::ComparisonOpS83,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2941,16 +3026,16 @@ fn goto_simpleexpression_s105(nonterm_kind: NonTermKind) -> State {
 }
 fn goto_tokencbopen_s106(nonterm_kind: NonTermKind) -> State {
     match nonterm_kind {
-        NonTermKind::Body => State::BodyS111,
-        NonTermKind::FunctionRead => State::FunctionReadS15,
-        NonTermKind::FunctionWrite => State::FunctionWriteS16,
-        NonTermKind::FunctionConvDate => State::FunctionConvDateS17,
-        NonTermKind::Expressions => State::ExpressionsS18,
-        NonTermKind::Statement => State::StatementS19,
-        NonTermKind::Assignment => State::AssignmentS20,
-        NonTermKind::WhileLoop => State::WhileLoopS21,
-        NonTermKind::IfStatement => State::IfStatementS22,
-        NonTermKind::ElseStatement => State::ElseStatementS23,
+        NonTermKind::Body => State::BodyS112,
+        NonTermKind::FunctionRead => State::FunctionReadS11,
+        NonTermKind::FunctionWrite => State::FunctionWriteS12,
+        NonTermKind::FunctionConvDate => State::FunctionConvDateS13,
+        NonTermKind::Expressions => State::ExpressionsS14,
+        NonTermKind::Statement => State::StatementS15,
+        NonTermKind::Assignment => State::AssignmentS16,
+        NonTermKind::WhileLoop => State::WhileLoopS17,
+        NonTermKind::IfStatement => State::IfStatementS18,
+        NonTermKind::ElseStatement => State::ElseStatementS19,
         _ => {
             panic!(
                 "Invalid terminal kind ({nonterm_kind:?}) for GOTO state ({:?}).",
@@ -2966,99 +3051,99 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
     actions: [
         action_aug_s0,
         action_tokenid_s1,
-        action_program_s2,
-        action_tokenparopen_s3,
-        action_tokenparclose_s4,
-        action_tokencbopen_s5,
-        action_tokenid_s6,
-        action_tokeninit_s7,
-        action_tokenwhile_s8,
-        action_tokenif_s9,
-        action_tokenelse_s10,
-        action_tokenread_s11,
-        action_tokenwrite_s12,
-        action_tokenconvdate_s13,
-        action_body_s14,
-        action_functionread_s15,
-        action_functionwrite_s16,
-        action_functionconvdate_s17,
-        action_expressions_s18,
-        action_statement_s19,
-        action_assignment_s20,
-        action_whileloop_s21,
-        action_ifstatement_s22,
-        action_elsestatement_s23,
-        action_tokenassign_s24,
-        action_tokencbopen_s25,
-        action_initbody_s26,
+        action_tokeninit_s2,
+        action_tokenwhile_s3,
+        action_tokenif_s4,
+        action_tokenelse_s5,
+        action_tokenread_s6,
+        action_tokenwrite_s7,
+        action_tokenconvdate_s8,
+        action_program_s9,
+        action_body_s10,
+        action_functionread_s11,
+        action_functionwrite_s12,
+        action_functionconvdate_s13,
+        action_expressions_s14,
+        action_statement_s15,
+        action_assignment_s16,
+        action_whileloop_s17,
+        action_ifstatement_s18,
+        action_elsestatement_s19,
+        action_tokenassign_s20,
+        action_tokenparopen_s21,
+        action_tokencbopen_s22,
+        action_initbody_s23,
+        action_tokenparopen_s24,
+        action_tokenparopen_s25,
+        action_tokencbopen_s26,
         action_tokenparopen_s27,
         action_tokenparopen_s28,
-        action_tokencbopen_s29,
-        action_tokenparopen_s30,
-        action_tokenparopen_s31,
-        action_tokenparopen_s32,
-        action_tokencbclose_s33,
-        action_expressions_s34,
-        action_tokenintliteral_s35,
-        action_tokenfloatliteral_s36,
-        action_tokenstringliteral_s37,
-        action_tokenid_s38,
-        action_tokensub_s39,
-        action_tokenparopen_s40,
-        action_simpleexpression_s41,
-        action_number_s42,
-        action_arithmeticexpression_s43,
-        action_term_s44,
-        action_factor_s45,
-        action_tokenid_s46,
-        action_vardeclarations_s47,
-        action_vardeclaration_s48,
-        action_expressions_s49,
-        action_tokentrue_s50,
-        action_tokenfalse_s51,
-        action_tokennot_s52,
-        action_tokeniszero_s53,
-        action_functioniszero_s54,
-        action_booleanexpression_s55,
-        action_simpleexpression_s56,
-        action_notstatement_s57,
-        action_booleanexpression_s58,
-        action_body_s59,
-        action_tokenid_s60,
-        action_simpleexpression_s61,
-        action_tokendate_s62,
-        action_tokenintliteral_s63,
-        action_tokenfloatliteral_s64,
-        action_arithmeticexpression_s65,
-        action_tokensum_s66,
-        action_tokensub_s67,
-        action_tokenmul_s68,
-        action_tokendiv_s69,
-        action_tokencolon_s70,
-        action_tokencomma_s71,
-        action_tokencbclose_s72,
-        action_vardeclarations_s73,
-        action_booleanexpression_s74,
-        action_tokenparopen_s75,
-        action_tokenparclose_s76,
-        action_tokenequal_s77,
-        action_tokennotequal_s78,
-        action_tokenless_s79,
-        action_tokenlessequal_s80,
-        action_tokengreater_s81,
-        action_tokengreaterequal_s82,
-        action_booleanexpressionchain_s83,
-        action_comparisonop_s84,
-        action_tokenparclose_s85,
-        action_tokencbclose_s86,
+        action_tokenparopen_s29,
+        action_tokenid_s30,
+        action_expressions_s31,
+        action_tokenintliteral_s32,
+        action_tokenfloatliteral_s33,
+        action_tokenstringliteral_s34,
+        action_tokenid_s35,
+        action_tokensub_s36,
+        action_tokenparopen_s37,
+        action_simpleexpression_s38,
+        action_number_s39,
+        action_arithmeticexpression_s40,
+        action_term_s41,
+        action_factor_s42,
+        action_tokenparclose_s43,
+        action_tokenid_s44,
+        action_vardeclarations_s45,
+        action_vardeclaration_s46,
+        action_expressions_s47,
+        action_tokentrue_s48,
+        action_tokenfalse_s49,
+        action_tokennot_s50,
+        action_tokeniszero_s51,
+        action_functioniszero_s52,
+        action_booleanexpression_s53,
+        action_simpleexpression_s54,
+        action_notstatement_s55,
+        action_booleanexpression_s56,
+        action_body_s57,
+        action_tokenid_s58,
+        action_simpleexpression_s59,
+        action_tokendate_s60,
+        action_tokenintliteral_s61,
+        action_tokenfloatliteral_s62,
+        action_arithmeticexpression_s63,
+        action_tokensum_s64,
+        action_tokensub_s65,
+        action_tokenmul_s66,
+        action_tokendiv_s67,
+        action_tokencbopen_s68,
+        action_tokencolon_s69,
+        action_tokencomma_s70,
+        action_tokencbclose_s71,
+        action_vardeclarations_s72,
+        action_booleanexpression_s73,
+        action_tokenparopen_s74,
+        action_tokenparclose_s75,
+        action_tokenequal_s76,
+        action_tokennotequal_s77,
+        action_tokenless_s78,
+        action_tokenlessequal_s79,
+        action_tokengreater_s80,
+        action_tokengreaterequal_s81,
+        action_booleanexpressionchain_s82,
+        action_comparisonop_s83,
+        action_tokenparclose_s84,
+        action_tokencbclose_s85,
+        action_tokenparclose_s86,
         action_tokenparclose_s87,
         action_tokenparclose_s88,
         action_tokenparclose_s89,
-        action_tokenparclose_s90,
+        action_term_s90,
         action_term_s91,
-        action_term_s92,
+        action_factor_s92,
         action_factor_s93,
-        action_factor_s94,
+        action_body_s94,
         action_tokenint_s95,
         action_tokenfloat_s96,
         action_tokenstring_s97,
@@ -3071,23 +3156,19 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         action_conjunction_s104,
         action_simpleexpression_s105,
         action_tokencbopen_s106,
-        action_tokenparclose_s107,
-        action_body_s108,
-        action_booleanexpression_s109,
-        action_booleanexpressionchain_s110,
-        action_body_s111,
-        action_tokencbclose_s112,
+        action_tokencbclose_s107,
+        action_tokenparclose_s108,
+        action_body_s109,
+        action_booleanexpression_s110,
+        action_booleanexpressionchain_s111,
+        action_body_s112,
         action_tokencbclose_s113,
+        action_tokencbclose_s114,
     ],
     gotos: [
         goto_aug_s0,
         goto_invalid,
-        goto_invalid,
-        goto_invalid,
-        goto_invalid,
-        goto_tokencbopen_s5,
-        goto_invalid,
-        goto_tokeninit_s7,
+        goto_tokeninit_s2,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3099,19 +3180,21 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_statement_s19,
+        goto_invalid,
+        goto_statement_s15,
         goto_invalid,
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_tokenassign_s24,
-        goto_tokencbopen_s25,
-        goto_initbody_s26,
-        goto_tokenparopen_s27,
+        goto_tokenassign_s20,
+        goto_invalid,
+        goto_tokencbopen_s22,
+        goto_initbody_s23,
+        goto_tokenparopen_s24,
+        goto_tokenparopen_s25,
+        goto_tokencbopen_s26,
+        goto_invalid,
         goto_tokenparopen_s28,
-        goto_tokencbopen_s29,
-        goto_invalid,
-        goto_tokenparopen_s31,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3120,7 +3203,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_tokenparopen_s40,
+        goto_tokenparopen_s37,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3128,15 +3211,16 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_vardeclaration_s48,
+        goto_invalid,
+        goto_vardeclaration_s46,
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_tokennot_s52,
+        goto_tokennot_s50,
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_simpleexpression_s56,
+        goto_simpleexpression_s54,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3146,16 +3230,17 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_tokensum_s66,
-        goto_tokensub_s67,
-        goto_tokenmul_s68,
-        goto_tokendiv_s69,
-        goto_tokencolon_s70,
-        goto_tokencomma_s71,
+        goto_tokensum_s64,
+        goto_tokensub_s65,
+        goto_tokenmul_s66,
+        goto_tokendiv_s67,
+        goto_tokencbopen_s68,
+        goto_tokencolon_s69,
+        goto_tokencomma_s70,
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_tokenparopen_s75,
+        goto_tokenparopen_s74,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3163,8 +3248,9 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
-        goto_booleanexpressionchain_s83,
-        goto_comparisonop_s84,
+        goto_booleanexpressionchain_s82,
+        goto_comparisonop_s83,
+        goto_invalid,
         goto_invalid,
         goto_invalid,
         goto_invalid,
@@ -3194,10 +3280,60 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         goto_invalid,
         goto_invalid,
         goto_invalid,
+        goto_invalid,
     ],
     token_kinds: [
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
+            Some((TK::TokenInit, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenAssign, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenCBOpen, false)),
+            None,
             None,
             None,
             None,
@@ -3221,6 +3357,127 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         ],
         [
             Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenCBOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParOpen, false)),
+            None,
             None,
             None,
             None,
@@ -3264,6 +3521,271 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
+        ],
+        [
+            Some((TK::STOP, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenCBClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
@@ -3287,55 +3809,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenCBOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
             Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenInit, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
             None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenAssign, false)),
             None,
             None,
             None,
@@ -3358,443 +3836,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
-            Some((TK::TokenCBOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenCBOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenCBClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenCBClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -3839,6 +3881,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenIntLiteral, false)),
@@ -3851,6 +3894,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenFalse, false)),
             Some((TK::TokenNot, false)),
             Some((TK::TokenIsZero, false)),
+            None,
             None,
             None,
             None,
@@ -3885,9 +3929,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenId, false)),
+            None,
             None,
             None,
             None,
@@ -3916,6 +3962,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenId, false)),
             Some((TK::TokenSub, false)),
             Some((TK::TokenParOpen, false)),
+            None,
             None,
             None,
             None,
@@ -3954,31 +4001,34 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::STOP, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
+            Some((TK::TokenAssign, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
             Some((TK::TokenCBClose, false)),
             None,
             None,
@@ -4002,6 +4052,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4025,6 +4076,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4048,6 +4100,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenParClose, false)),
             Some((TK::TokenCBClose, false)),
@@ -4071,6 +4124,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4096,6 +4150,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         [
             Some((TK::TokenIntLiteral, false)),
             Some((TK::TokenFloatLiteral, false)),
+            None,
             None,
             None,
             None,
@@ -4138,8 +4193,10 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -4163,52 +4220,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSum, false)),
-            Some((TK::TokenMul, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenDiv, false)),
-            Some((TK::TokenParClose, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenEqual, false)),
-            Some((TK::TokenNotEqual, false)),
-            Some((TK::TokenLess, false)),
-            Some((TK::TokenLessEqual, false)),
-            Some((TK::TokenGreater, false)),
-            Some((TK::TokenGreaterEqual, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenAnd, false)),
-            Some((TK::TokenOr, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSum, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParClose, false)),
-            Some((TK::TokenCBClose, false)),
-            Some((TK::TokenWhile, false)),
-            Some((TK::TokenEqual, false)),
-            Some((TK::TokenNotEqual, false)),
-            Some((TK::TokenLess, false)),
-            Some((TK::TokenLessEqual, false)),
-            Some((TK::TokenGreater, false)),
-            Some((TK::TokenGreaterEqual, false)),
-            Some((TK::TokenIf, false)),
-            Some((TK::TokenElse, false)),
-            Some((TK::TokenAnd, false)),
-            Some((TK::TokenOr, false)),
-            Some((TK::TokenRead, false)),
-            Some((TK::TokenWrite, false)),
-            Some((TK::TokenConvDate, false)),
-            None,
-            None,
-        ],
-        [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4232,6 +4244,31 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSum, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParClose, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenEqual, false)),
+            Some((TK::TokenNotEqual, false)),
+            Some((TK::TokenLess, false)),
+            Some((TK::TokenLessEqual, false)),
+            Some((TK::TokenGreater, false)),
+            Some((TK::TokenGreaterEqual, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenAnd, false)),
+            Some((TK::TokenOr, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4253,6 +4290,54 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenRead, false)),
             Some((TK::TokenWrite, false)),
             Some((TK::TokenConvDate, false)),
+        ],
+        [
+            Some((TK::STOP, true)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSum, false)),
+            Some((TK::TokenMul, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenDiv, false)),
+            Some((TK::TokenParClose, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenEqual, false)),
+            Some((TK::TokenNotEqual, false)),
+            Some((TK::TokenLess, false)),
+            Some((TK::TokenLessEqual, false)),
+            Some((TK::TokenGreater, false)),
+            Some((TK::TokenGreaterEqual, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenAnd, false)),
+            Some((TK::TokenOr, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
+        ],
+        [
+            Some((TK::TokenCBOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ],
         [
             Some((TK::TokenColon, false)),
@@ -4276,9 +4361,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenCBClose, false)),
+            None,
             None,
             None,
             None,
@@ -4322,8 +4409,10 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenCBClose, false)),
             None,
             None,
@@ -4368,9 +4457,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -4414,6 +4505,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenParOpen, false)),
@@ -4437,32 +4529,35 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenParClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -4506,32 +4601,35 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenParClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -4575,28 +4673,6 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenParClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
@@ -4621,6 +4697,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
@@ -4644,8 +4721,34 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
+            Some((TK::TokenParClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4669,6 +4772,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -4713,28 +4817,6 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
@@ -4744,28 +4826,6 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenSub, false)),
             Some((TK::TokenParOpen, false)),
             None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
             None,
             None,
             None,
@@ -4792,6 +4852,79 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            Some((TK::TokenInit, false)),
+            Some((TK::TokenWhile, false)),
+            Some((TK::TokenIf, false)),
+            Some((TK::TokenElse, false)),
+            Some((TK::TokenRead, false)),
+            Some((TK::TokenWrite, false)),
+            Some((TK::TokenConvDate, false)),
             None,
             None,
             None,
@@ -4828,6 +4961,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenId, false)),
@@ -4851,8 +4985,10 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -4897,9 +5033,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -4924,6 +5062,223 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
         [
             Some((TK::TokenIntLiteral, false)),
             Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenCBOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenParClose, false)),
+            Some((TK::TokenAnd, false)),
+            Some((TK::TokenOr, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSub, false)),
             Some((TK::TokenParOpen, false)),
@@ -4966,215 +5321,10 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenParClose, false)),
-            Some((TK::TokenAnd, false)),
-            Some((TK::TokenOr, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
-            Some((TK::TokenCBOpen, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
-        [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -5198,6 +5348,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -5221,6 +5372,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -5244,6 +5396,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -5267,6 +5420,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -5290,6 +5444,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -5313,6 +5468,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -5336,6 +5492,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -5359,6 +5516,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenSum, false)),
             Some((TK::TokenMul, false)),
@@ -5382,8 +5540,9 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenConvDate, false)),
         ],
         [
-            Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
+            None,
+            None,
             None,
             None,
             None,
@@ -5426,28 +5585,6 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenId, false)),
-            Some((TK::TokenCBClose, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
@@ -5472,10 +5609,60 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenId, false)),
+            Some((TK::TokenCBClose, false)),
+            None,
             None,
             None,
             None,
@@ -5500,6 +5687,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenSum, false)),
             Some((TK::TokenSub, false)),
             Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -5541,28 +5729,6 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
-        ],
-        [
-            Some((TK::TokenIntLiteral, false)),
-            Some((TK::TokenFloatLiteral, false)),
-            Some((TK::TokenStringLiteral, false)),
-            Some((TK::TokenId, false)),
-            Some((TK::TokenSub, false)),
-            Some((TK::TokenParOpen, false)),
-            Some((TK::TokenTrue, false)),
-            Some((TK::TokenFalse, false)),
-            Some((TK::TokenNot, false)),
-            Some((TK::TokenIsZero, false)),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
             None,
         ],
         [
@@ -5587,6 +5753,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenIntLiteral, false)),
@@ -5599,6 +5766,31 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenFalse, false)),
             Some((TK::TokenNot, false)),
             Some((TK::TokenIsZero, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            Some((TK::TokenIntLiteral, false)),
+            Some((TK::TokenFloatLiteral, false)),
+            Some((TK::TokenStringLiteral, false)),
+            Some((TK::TokenId, false)),
+            Some((TK::TokenSub, false)),
+            Some((TK::TokenParOpen, false)),
+            Some((TK::TokenTrue, false)),
+            Some((TK::TokenFalse, false)),
+            Some((TK::TokenNot, false)),
+            Some((TK::TokenIsZero, false)),
+            None,
             None,
             None,
             None,
@@ -5621,6 +5813,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             Some((TK::TokenGreaterEqual, false)),
             Some((TK::TokenAnd, false)),
             Some((TK::TokenOr, false)),
+            None,
             None,
             None,
             None,
@@ -5656,9 +5849,35 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
+        ],
+        [
+            Some((TK::STOP, false)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -5702,9 +5921,11 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenParClose, false)),
+            None,
             None,
             None,
             None,
@@ -5748,6 +5969,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
             Some((TK::TokenCBClose, false)),
@@ -5771,8 +5993,10 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
             None,
             None,
+            None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -5796,6 +6020,7 @@ pub(crate) static PARSER_DEFINITION: GrammarParserDefinition = GrammarParserDefi
             None,
         ],
         [
+            Some((TK::STOP, true)),
             Some((TK::TokenId, false)),
             Some((TK::TokenCBClose, false)),
             Some((TK::TokenWhile, false)),
@@ -6068,7 +6293,7 @@ for DefaultBuilder {
         prod_len: usize,
     ) {
         let prod = match prod {
-            ProdKind::ProgramProgram => {
+            ProdKind::ProgramProgramWithMain => {
                 let mut i = self
                     .res_stack
                     .split_off(self.res_stack.len() - 6usize)
@@ -6090,7 +6315,7 @@ for DefaultBuilder {
                         Symbol::Terminal(Terminal::TokenCBClose(p5)),
                     ) => {
                         NonTerminal::Program(
-                            grammar_actions::program_program(
+                            grammar_actions::program_program_with_main(
                                 context,
                                 p0,
                                 p1,
@@ -6099,6 +6324,20 @@ for DefaultBuilder {
                                 p4,
                                 p5,
                             ),
+                        )
+                    }
+                    _ => panic!("Invalid symbol parse stack data."),
+                }
+            }
+            ProdKind::ProgramProgramOnlyBody => {
+                let mut i = self
+                    .res_stack
+                    .split_off(self.res_stack.len() - 1usize)
+                    .into_iter();
+                match i.next().unwrap() {
+                    Symbol::NonTerminal(NonTerminal::Body(p0)) => {
+                        NonTerminal::Program(
+                            grammar_actions::program_program_only_body(context, p0),
                         )
                     }
                     _ => panic!("Invalid symbol parse stack data."),

--- a/src/grammar.rustemo
+++ b/src/grammar.rustemo
@@ -1,4 +1,5 @@
-Program: TokenId TokenParOpen TokenParClose TokenCBOpen Body TokenCBClose {Program};
+Program: TokenId TokenParOpen TokenParClose TokenCBOpen Body TokenCBClose {ProgramWithMain}
+ | Body {ProgramOnlyBody};
 
 Body: TokenInit InitBody Expressions {BodyInitExpressions}
  | TokenInit InitBody {BodyInit}

--- a/src/grammar_actions.rs
+++ b/src/grammar_actions.rs
@@ -241,7 +241,7 @@ pub fn token_date(_ctx: &Ctx, token: Token) -> TokenDate {
     token.value.into()
 }
 #[derive(Debug, Clone)]
-pub struct Program {
+pub struct ProgramWithMain {
     pub token_id: TokenId,
     pub token_par_open: TokenParOpen,
     pub token_par_close: TokenParClose,
@@ -249,7 +249,12 @@ pub struct Program {
     pub body: Body,
     pub token_cbclose: TokenCBClose,
 }
-pub fn program_program(
+#[derive(Debug, Clone)]
+pub enum Program {
+    ProgramWithMain(ProgramWithMain),
+    ProgramOnlyBody(Body),
+}
+pub fn program_program_with_main(
     _ctx: &Ctx,
     token_id: TokenId,
     token_par_open: TokenParOpen,
@@ -261,14 +266,18 @@ pub fn program_program(
     write_to_parser_file(&format!(
         "<Program> -> {token_id} {token_par_open} {token_par_close} {token_cbopen} <Body> {token_cbclose}"
     ));
-    Program {
+    Program::ProgramWithMain(ProgramWithMain {
         token_id,
         token_par_open,
         token_par_close,
         token_cbopen,
         body,
         token_cbclose,
-    }
+    })
+}
+pub fn program_program_only_body(_ctx: &Ctx, body: Body) -> Program {
+    write_to_parser_file(&format!("<Program> -> <Body>"));
+    Program::ProgramOnlyBody(body)
 }
 #[derive(Debug, Clone)]
 pub struct BodyInitExpressions {


### PR DESCRIPTION
**Description**

This PR adds a second rule for `Program` non terminal that does not require the `main() {}` declaration. For now we keep the rule with `main()` but it might be removed later