### PR TITLE
fix: move literal validations to lexer

### DIFF
--- a/inputs/test.txt
+++ b/inputs/test.txt
@@ -45,4 +45,11 @@ read(f6f)
 #+ Ejemplo de error por entero mayor a 64 bits +#
 #+ x:= 18446744073709551616 +#
 
+#+ Ejemplo de error por string muy larga (mayor a 256 chars) +#
+#+ f := "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum" +#
+
+#+ Ejemplo de error por float invalido +#
+#+ x := 1001247380987123904721309473201974012938740921374091237409127340983217094874.1234 +#
+
+
 convDate(01-02-1900)

--- a/src/grammar_lexer.rs
+++ b/src/grammar_lexer.rs
@@ -49,7 +49,7 @@ impl<'i> Lexer<'i, Ctx<'i>, State, TokenKind> for LexerAdapter {
             token = TokenKind::STOP
         } else {
             let trimmed_input = input.get(context.position()..input.len()).unwrap();
-            let mut lexer = crate::lex::Lexer::new(trimmed_input);
+            let mut lexer = crate::lex::Lexer::new(trimmed_input, pos);
             token =
                 match validate_and_get_next_token(&mut lexer, expected_tokens, expected_tokens_str)
                 {

--- a/src/lex.l
+++ b/src/lex.l
@@ -1,7 +1,10 @@
 use crate::grammar::TokenKind;
+use crate::grammar_lexer::log_error;
+use crate::read_source_to_string;
 
 %%
 %class Lexer
+%field usize offset
 %result_type TokenKind
 
 
@@ -23,10 +26,56 @@ use crate::grammar::TokenKind;
 "isZero"                                                        return Ok(TokenKind::TokenIsZero);
 "convDate"                                                      return Ok(TokenKind::TokenConvDate);
 ([0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9])                    return Ok(TokenKind::TokenDate);
-([0-9]+)                                                        return Ok(TokenKind::TokenIntLiteral);
-(([0-9]+("."[0-9]*)?|"."[0-9]+)([eE][-+]?[0-9]+)?)              return Ok(TokenKind::TokenFloatLiteral);
+([0-9]+)                                                        {
+                                                                    if let Err(e) = self.yytext().parse::<u64>() {
+                                                                        log_error(
+                                                                            self.yytextpos(),
+                                                                            crate::CompilerError::Lexer(format!("Invalid integer literal {e}")),
+                                                                            self.offset,
+                                                                            &read_source_to_string().unwrap(),
+                                                                        );
+                                                                        std::process::exit(1)
+                                                                    }
+                                                                    return Ok(TokenKind::TokenIntLiteral);
+                                                                }
+(([0-9]+("."[0-9]*)?|"."[0-9]+)([eE][-+]?[0-9]+)?)              {
+                                                                    match self.yytext().parse::<f32>() {
+                                                                        Err(e) => {
+                                                                            log_error(
+                                                                                self.yytextpos(),
+                                                                                crate::CompilerError::Lexer(format!("Invalid float literal {e}")),
+                                                                                self.offset,
+                                                                                &read_source_to_string().unwrap(),
+                                                                            );
+                                                                            std::process::exit(1)
+                                                                        }
+                                                                        Ok(value) => {
+                                                                            if !value.is_normal() {
+                                                                                log_error(
+                                                                                self.yytextpos(),
+                                                                                crate::CompilerError::Lexer(format!("Invalid float literal")),
+                                                                                self.offset,
+                                                                                &read_source_to_string().unwrap(),
+                                                                            );
+                                                                            std::process::exit(1)
+                                                                            }
+                                                                        }
+                                                                    };
+                                                                    return Ok(TokenKind::TokenFloatLiteral);
+                                                                }
 [a-zA-Z]([a-zA-Z]|[0-9])*                                       return Ok(TokenKind::TokenId);
-\"([^\"\\\r\n#]|\\.)*\"                                         return Ok(TokenKind::TokenStringLiteral);
+\"([^\"\\\r\n#]|\\.)*\"                                         {
+                                                                    if self.yytext().len() > 256 {
+                                                                        log_error(
+                                                                            self.yytextpos(),
+                                                                            crate::CompilerError::Lexer(format!("Invalid string length {}", self.yytext().len())),
+                                                                            self.offset,
+                                                                            &read_source_to_string().unwrap(),
+                                                                        );
+                                                                        std::process::exit(1);
+                                                                    }
+                                                                    return Ok(TokenKind::TokenStringLiteral);
+                                                                }
 ":="                                                            return Ok(TokenKind::TokenAssign);
 "+"                                                             return Ok(TokenKind::TokenSum);
 "*"                                                             return Ok(TokenKind::TokenMul);


### PR DESCRIPTION
**Description**

This PR moves the validations for the token literals to the lexer. It also adds validations for strings longer than 256 characters and uses f32 instead of f64 for floats.
Modifies the test data to test these validations