### PR TITLE
fix: remove duplicates from symbol table, forbid var redeclarations

### DIFF
--- a/inputs/test.txt
+++ b/inputs/test.txt
@@ -6,9 +6,13 @@ init {
     #+ Ejemplo de una variable mal declarada +#
     #+ fecha : date +#
     #+ h : foat +#
+
+    #+ Ejemplo de error por redeclaracion de variable +#
+    #+ a1: int +#
 }
 
 a1 := -125
+b2 := -125
 b2 := a1
 
 c33 := 5.34

--- a/src/lex.l
+++ b/src/lex.l
@@ -1,6 +1,6 @@
 use crate::grammar::TokenKind;
-use crate::grammar_lexer::log_error;
-use crate::read_source_to_string;
+use crate::CompilerError;
+use crate::log_error_and_exit;
 
 %%
 %class Lexer
@@ -27,37 +27,34 @@ use crate::read_source_to_string;
 "convDate"                                                      return Ok(TokenKind::TokenConvDate);
 ([0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9])                    return Ok(TokenKind::TokenDate);
 ([0-9]+)                                                        {
-                                                                    if let Err(e) = self.yytext().parse::<u64>() {
-                                                                        log_error(
+                                                                    if let Err(e) = self.yytext().parse::<i64>() {
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid integer literal {e}")),
+                                                                            CompilerError::Lexer(format!("Invalid integer literal {e}")),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1)
+                                                                            true
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenIntLiteral);
                                                                 }
 (([0-9]+("."[0-9]*)?|"."[0-9]+)([eE][-+]?[0-9]+)?)              {
                                                                     match self.yytext().parse::<f32>() {
                                                                         Err(e) => {
-                                                                            log_error(
+                                                                            log_error_and_exit(
                                                                                 self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal {e}")),
+                                                                                CompilerError::Lexer(format!("Invalid float literal {e}")),
                                                                                 self.offset,
-                                                                                &read_source_to_string().unwrap(),
+                                                                                true,
                                                                             );
-                                                                            std::process::exit(1)
                                                                         }
                                                                         Ok(value) => {
                                                                             if !value.is_normal() {
-                                                                                log_error(
-                                                                                self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal")),
-                                                                                self.offset,
-                                                                                &read_source_to_string().unwrap(),
-                                                                            );
-                                                                            std::process::exit(1)
+                                                                                log_error_and_exit(
+                                                                                    self.yytextpos(),
+                                                                                    CompilerError::Lexer(format!("Invalid float literal")),
+                                                                                    self.offset,
+                                                                                    true,
+                                                                                )
                                                                             }
                                                                         }
                                                                     };
@@ -66,13 +63,12 @@ use crate::read_source_to_string;
 [a-zA-Z]([a-zA-Z]|[0-9])*                                       return Ok(TokenKind::TokenId);
 \"([^\"\\\r\n#]|\\.)*\"                                         {
                                                                     if self.yytext().len() > 256 {
-                                                                        log_error(
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid string length {}", self.yytext().len())),
+                                                                            CompilerError::Lexer(format!("Invalid string length {}", self.yytext().len())),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1);
+                                                                            true,
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenStringLiteral);
                                                                 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,6 +1,6 @@
 use crate::grammar::TokenKind;
-use crate::grammar_lexer::log_error;
-use crate::read_source_to_string;
+use crate::CompilerError;
+use crate::log_error_and_exit;
 
 
 use std::collections::HashMap;
@@ -360,14 +360,13 @@ impl<'a> Lexer<'a> {
                     14 => { return Ok(TokenKind::TokenId); }
                     106 => { /* nothing */ }
                     15 => { {
-                                                                    if let Err(e) = self.yytext().parse::<u64>() {
-                                                                        log_error(
+                                                                    if let Err(e) = self.yytext().parse::<i64>() {
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid integer literal {e}")),
+                                                                            CompilerError::Lexer(format!("Invalid integer literal {e}")),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1)
+                                                                            true
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenIntLiteral);
                                                                 } }
@@ -402,13 +401,12 @@ impl<'a> Lexer<'a> {
                     121 => { /* nothing */ }
                     30 => { {
                                                                     if self.yytext().len() > 256 {
-                                                                        log_error(
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid string length {}", self.yytext().len())),
+                                                                            CompilerError::Lexer(format!("Invalid string length {}", self.yytext().len())),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1);
+                                                                            true,
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenStringLiteral);
                                                                 } }
@@ -444,14 +442,13 @@ impl<'a> Lexer<'a> {
                     45 => { return Ok(TokenKind::TokenId); }
                     137 => { /* nothing */ }
                     46 => { {
-                                                                    if let Err(e) = self.yytext().parse::<u64>() {
-                                                                        log_error(
+                                                                    if let Err(e) = self.yytext().parse::<i64>() {
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid integer literal {e}")),
+                                                                            CompilerError::Lexer(format!("Invalid integer literal {e}")),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1)
+                                                                            true
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenIntLiteral);
                                                                 } }
@@ -459,23 +456,21 @@ impl<'a> Lexer<'a> {
                     47 => { {
                                                                     match self.yytext().parse::<f32>() {
                                                                         Err(e) => {
-                                                                            log_error(
+                                                                            log_error_and_exit(
                                                                                 self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal {e}")),
+                                                                                CompilerError::Lexer(format!("Invalid float literal {e}")),
                                                                                 self.offset,
-                                                                                &read_source_to_string().unwrap(),
+                                                                                true,
                                                                             );
-                                                                            std::process::exit(1)
                                                                         }
                                                                         Ok(value) => {
                                                                             if !value.is_normal() {
-                                                                                log_error(
-                                                                                self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal")),
-                                                                                self.offset,
-                                                                                &read_source_to_string().unwrap(),
-                                                                            );
-                                                                            std::process::exit(1)
+                                                                                log_error_and_exit(
+                                                                                    self.yytextpos(),
+                                                                                    CompilerError::Lexer(format!("Invalid float literal")),
+                                                                                    self.offset,
+                                                                                    true,
+                                                                                )
                                                                             }
                                                                         }
                                                                     };
@@ -523,23 +518,21 @@ impl<'a> Lexer<'a> {
                     67 => { {
                                                                     match self.yytext().parse::<f32>() {
                                                                         Err(e) => {
-                                                                            log_error(
+                                                                            log_error_and_exit(
                                                                                 self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal {e}")),
+                                                                                CompilerError::Lexer(format!("Invalid float literal {e}")),
                                                                                 self.offset,
-                                                                                &read_source_to_string().unwrap(),
+                                                                                true,
                                                                             );
-                                                                            std::process::exit(1)
                                                                         }
                                                                         Ok(value) => {
                                                                             if !value.is_normal() {
-                                                                                log_error(
-                                                                                self.yytextpos(),
-                                                                                crate::CompilerError::Lexer(format!("Invalid float literal")),
-                                                                                self.offset,
-                                                                                &read_source_to_string().unwrap(),
-                                                                            );
-                                                                            std::process::exit(1)
+                                                                                log_error_and_exit(
+                                                                                    self.yytextpos(),
+                                                                                    CompilerError::Lexer(format!("Invalid float literal")),
+                                                                                    self.offset,
+                                                                                    true,
+                                                                                )
                                                                             }
                                                                         }
                                                                     };
@@ -547,14 +540,13 @@ impl<'a> Lexer<'a> {
                                                                 } }
                     159 => { /* nothing */ }
                     68 => { {
-                                                                    if let Err(e) = self.yytext().parse::<u64>() {
-                                                                        log_error(
+                                                                    if let Err(e) = self.yytext().parse::<i64>() {
+                                                                        log_error_and_exit(
                                                                             self.yytextpos(),
-                                                                            crate::CompilerError::Lexer(format!("Invalid integer literal {e}")),
+                                                                            CompilerError::Lexer(format!("Invalid integer literal {e}")),
                                                                             self.offset,
-                                                                            &read_source_to_string().unwrap(),
-                                                                        );
-                                                                        std::process::exit(1)
+                                                                            true
+                                                                        )
                                                                     }
                                                                     return Ok(TokenKind::TokenIntLiteral);
                                                                 } }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,9 @@ mod context;
 mod grammar_lexer;
 
 pub use context::{
-    CompilerError, open_lexer_file, open_parser_file, open_symbol_table_file,
-    read_parser_file_to_string, read_source_to_string, set_source_file_path,
+    CompilerError, dump_symbol_table_to_file, log_error_and_exit, open_lexer_file,
+    open_parser_file, open_symbol_table_file, read_parser_file_to_string, read_source_to_string,
+    set_source_file_path,
 };
 pub use grammar::GrammarParser;
 pub use grammar_lexer::LexerAdapter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser as ClapParser;
 use lm_compiler::{
-    CompilerError, GrammarParser, LexerAdapter, open_lexer_file, open_parser_file,
-    open_symbol_table_file, read_parser_file_to_string, read_source_to_string,
+    CompilerError, GrammarParser, LexerAdapter, dump_symbol_table_to_file, open_lexer_file,
+    open_parser_file, open_symbol_table_file, read_parser_file_to_string, read_source_to_string,
     set_source_file_path,
 };
 use rustemo::Parser;
@@ -28,6 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .parse(&read_source_to_string()?)
         .map_err(CompilerError::ParserInternal)?;
 
+    dump_symbol_table_to_file()?;
     println!("{}", read_parser_file_to_string()?);
 
     Ok(())

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -1,6 +1,6 @@
 use lm_compiler::{
-    GrammarParser, LexerAdapter, open_lexer_file, open_parser_file, open_symbol_table_file,
-    read_source_to_string, set_source_file_path,
+    GrammarParser, LexerAdapter, dump_symbol_table_to_file, open_lexer_file, open_parser_file,
+    open_symbol_table_file, read_source_to_string, set_source_file_path,
 };
 use rustemo::Parser;
 use std::path::Path;
@@ -14,7 +14,7 @@ fn integration_test(path: &Path) -> datatest_stable::Result<()> {
     GrammarParser::new(LexerAdapter::new())
         .parse(&read_source_to_string().map_err(|err| err.to_string())?)
         .map_err(|err| err.to_string().into())
-        .map(|_program| ())
+        .and_then(|_program| dump_symbol_table_to_file().map_err(|e| e.to_string().into()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Description**

This PR modifies the symbol table creation logic by:
- Storing the table as a global variable in the form of a Vec, every time we parse a symbol we push it to this vector
- If compilation is successful or we exit with an error we first dump the table into a file
- When parsing the variable declarations inside `init {}` if we find a symbol that is already in the table we exit with an error.
This PR also modifies the parsing of negative floats and integers:
- The enum variants `NumberNegativeInt` and `NumberNegativeInt` were removed in favor of using i64 and f32 to store negatives.